### PR TITLE
Add ProjectReference test

### DIFF
--- a/test/Microsoft.Buld.Sql.Tests/BuildTestBase.cs
+++ b/test/Microsoft.Buld.Sql.Tests/BuildTestBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Build.Sql.Tests
 {
     public abstract class BuildTestBase
     {
-        protected const string DatabaseProjectName = "project";
+        private const string DatabaseProjectName = "project";
 
         protected string WorkingDirectory
         {
@@ -185,6 +185,14 @@ namespace Microsoft.Build.Sql.Tests
         }
 
         /// <summary>
+        /// Add references to another project(s). <paramref name="projects"/> paths are relative.
+        /// </summary>
+        protected void AddProjectReference(params string[] projects)
+        {
+            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "ProjectReference", projects);
+        }
+
+        /// <summary>
         /// Returns the full path to the sqlproj file used for this test.
         /// </summary>
         protected string GetProjectFilePath()
@@ -200,6 +208,11 @@ namespace Microsoft.Build.Sql.Tests
             return Path.Combine(this.WorkingDirectory, "bin/Debug", DatabaseProjectName + ".dacpac");
         }
 
+        /// <summary>
+        /// Verifies dacpac exists in the build output directory, and checks if it contains pre/post deploy scripts.
+        /// </summary>
+        /// <param name="expectPreDeployScript">If true, asserts dacpac has pre-deploy script attached.</param>
+        /// <param name="expectPostDeployScript">If true, asserts dacpac has post-deploy script attached.</param>
         protected void VerifyDacPackage(bool expectPreDeployScript = false, bool expectPostDeployScript = false)
         {
             // Verify dacpac exists

--- a/test/Microsoft.Buld.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Buld.Sql.Tests/BuildTests.cs
@@ -137,5 +137,22 @@ namespace Microsoft.Build.Sql.Tests
             // Verify failure
             Assert.AreEqual(1, exitCode, "Build is expected to fail.");
         }
+
+        [Test]
+        public void VerifyBuildWithProjectReference()
+        {
+             this.AddProjectReference("ReferenceProj/ReferenceProj.sqlproj");
+
+             // Since reference proj is in a subdirectory it gets picked up by default globbing pattern, excluding it here
+             this.RemoveBuildFiles("ReferenceProj/**/*.*");
+
+             string stdOutput, stdError;
+             int exitCode = this.Build(out stdOutput, out stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+        }
     }
 }

--- a/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReference/ReferenceProj/ReferenceProj.sqlproj
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReference/ReferenceProj/ReferenceProj.sqlproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build">
+  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <PropertyGroup>
+    <Name>ReferenceProj</Name>
+    <DSP>Microsoft.Data.Tools.Schema.Sql.Sql150DatabaseSchemaProvider</DSP>
+    <ModelCollation>1033, CI</ModelCollation>
+  </PropertyGroup>
+</Project>

--- a/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReference/ReferenceProj/Table1.sql
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReference/ReferenceProj/Table1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[Table1]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)

--- a/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReference/View1.sql
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReference/View1.sql
@@ -1,0 +1,3 @@
+-- This view references Table1 which is created in the ReferenceProj
+CREATE VIEW [dbo].[View1]
+  AS SELECT * FROM [Table1]

--- a/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReferenceInSubdirectory/ReferenceProj/ReferenceProj.sqlproj
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReferenceInSubdirectory/ReferenceProj/ReferenceProj.sqlproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build">
+  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <PropertyGroup>
+    <Name>ReferenceProj</Name>
+    <DSP>Microsoft.Data.Tools.Schema.Sql.Sql150DatabaseSchemaProvider</DSP>
+    <ModelCollation>1033, CI</ModelCollation>
+  </PropertyGroup>
+</Project>

--- a/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReferenceInSubdirectory/ReferenceProj/Table1.sql
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReferenceInSubdirectory/ReferenceProj/Table1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[Table1]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)

--- a/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReferenceInSubdirectory/View1.sql
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithProjectReferenceInSubdirectory/View1.sql
@@ -1,0 +1,3 @@
+-- This view references Table1 which is created in the ReferenceProj
+CREATE VIEW [dbo].[View1]
+  AS SELECT * FROM [Table1]


### PR DESCRIPTION
Looks like Project GUID isn't required

Also the command `dotnet add reference` works too but it needs `<NetCoreBuild>true</NetCoreBuild>` in the project file. Maybe we will default this to true in the SDK after all.