### PR TITLE
Downgrade .NET SDK to 2.1.x for Code Sign task

### DIFF
--- a/builds/template-steps-build-test.yml
+++ b/builds/template-steps-build-test.yml
@@ -27,10 +27,10 @@ steps:
 
 # CodeSign is only run on release builds
 - task: UseDotNet@2
-  displayName: 'Install .NET SDK 5.0.x for CodeSign'
+  displayName: 'Install .NET Core SDK 2.1.x for CodeSign'
   condition: '${{ parameters.runCodeSign }}'
   inputs:
-    version: '5.0.x'
+    version: '2.1.x'
 
 # CodeSign DLLs included in the SDK
 - task: EsrpCodeSigning@1


### PR DESCRIPTION
The release pipeline started failing over the weekend, looks like the Code Sign team forced the task to use 2.1.x: https://aka.ms/esrp.signtask