### PR TITLE
Some code cleanup

### DIFF
--- a/samples/SdkStyleDatabaseProject/nuget.config
+++ b/samples/SdkStyleDatabaseProject/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
-    <add key="LocalNugetSource" value="..\..\src\Microsoft.Build.Sql\bin\Debug" />
-  </packageSources>
-</configuration>

--- a/samples/SdkStyleDatabaseProject/sample.sqlproj
+++ b/samples/SdkStyleDatabaseProject/sample.sqlproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <Sdk Name="Microsoft.Build.Sql" Version="0.1.1-alpha" />
   <PropertyGroup>
     <Name>sample</Name>
     <DSP>Microsoft.Data.Tools.Schema.Sql.Sql150DatabaseSchemaProvider</DSP>

--- a/src/Microsoft.Build.Sql/README.md
+++ b/src/Microsoft.Build.Sql/README.md
@@ -8,16 +8,6 @@ This project is in its early stages and we are currently building tests for diff
 
 ## Using this SDK
 
-### Add GitHub Packages as Nuget Source
-To add GitHub Packages as a package source, you must first generate a Personal Access Token (PAT) with your GitHub credentials. [For more information](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry#authenticating-to-github-packages)
-1. You can generate a PAT from here: https://github.com/settings/tokens
-   * Make sure it has *read:packages* scope
-2. Save the PAT to a secure place
-3. Run this command to add GitHub Packages as a package source (replace GITHUB_USERNAME and GITHUB_PAT with those of your own):
-```
-dotnet nuget add source "https://nuget.pkg.github.com/microsoft/index.json" --name github --username "GITHUB_USERNAME" --password "GITHUB_PAT" --store-password-in-clear-text
-```
-
 ### Changes to .sqlproj file
 To convert a database project into SDK-style, edit the .sqlproj file by adding
 ```xml


### PR DESCRIPTION
Since v0.1.1-alpha has been [published to Nuget.org](https://www.nuget.org/packages/Microsoft.Build.Sql/0.1.1-alpha), the instructions in README to add Github Packages as feed is no longer needed.