### PR TITLE
Add nightly tests against latest DacFx changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Microsoft.Build.Sql SDK will use DLLs from this version of DacFx Nuget. -->
+    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">160.5332.1-preview</DacFxPackageVersion>
+  </PropertyGroup>
+</Project>

--- a/builds/build-pr.yml
+++ b/builds/build-pr.yml
@@ -40,3 +40,4 @@ stages:
         configuration: '$(configuration)'
         nugetVersion: '1.0.0'
         runCodeSign: 'false'
+        dacFxPackageVersion: ''

--- a/builds/build-release.yml
+++ b/builds/build-release.yml
@@ -34,6 +34,7 @@ stages:
           configuration: '$(configuration)'
           nugetVersion: '$(nugetVersion)'
           runCodeSign: 'true'
+          dacFxPackageVersion: ''
 
       - template: 'template-steps-publish.yml'
         parameters:

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -2,18 +2,21 @@ trigger: none
 
 pr: none
 
+variables:
+  solution: '**/*.sln'
+  configuration: 'Debug'
+  azureSourcePipelineName: ''  # Set in Azure pipeline
+  azureSourcePipelineId: ''    # Set in Azure pipeline
+  azureProjectId: ''           # Set in Azure pipeline
+  dacFxPackagePattern: 'Microsoft.SqlServer.DacFx*-preview.nupkg'
+  dacFxPackagePath: '$(Pipeline.Workspace)/pkg'  # DacFx nupkg will be downloaded from nightly build and placed here
+
 # Pipeline trigger - this pipeline will run whenever the 'DacFx Nuget - Nightly' pipeline finishes
 resources:
   pipelines:
   - pipeline: 'github-build-test-nightly'
-    source: '$(source-pipeline-name)'
+    source: '$(azureSourcePipelineName)'
     trigger: true
-
-variables:
-  solution: '**/*.sln'
-  configuration: 'Debug'
-  dacFxPackagePattern: 'Microsoft.SqlServer.DacFx*-preview.nupkg'
-  dacFxPackagePath: '$(Pipeline.Workspace)/pkg'  # DacFx nupkg will be downloaded from nightly build and placed here
 
 stages:
 - stage: Build
@@ -44,8 +47,8 @@ stages:
       displayName: 'Download Pipeline Artifact'
       inputs:
         buildType: 'specific'
-        project: '$(ado-project-id)'
-        definition: '$(source-pipeline-id)'
+        project: '$(azureProjectId)'
+        definition: '$(azureSourcePipelineId)'
         buildVersionToDownload: 'latest'
         artifactName: 'drop'
         itemPattern: '$(dacFxPackagePattern)'

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -15,7 +15,7 @@ variables:
 resources:
   pipelines:
   - pipeline: 'github-build-test-nightly'
-    source: '$(azureSourcePipelineName)'
+    source: 'DacFx Nuget - Nightly'
     trigger: true
 
 stages:

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -62,15 +62,15 @@ stages:
         script: |
           # Locate the nupkg file from the package path
           $files =  Get-ChildItem "$(dacFxPackagePath)" -Recurse -Include "$(dacFxPackagePattern)"
-          if ($files.length -ne 1) {
+          if ($files.length -eq 0) {
             Write-Error "Failed to find Nuget package with pattern $(dacFxPackagePattern) in $(dacFxPackagePath)"
           }
 
-          # # Parse the nupkg file name for the version number
-          # $filename = Split-Path $files[0] -leaf
-          # $version = $filename.Replace("Microsoft.SqlServer.DacFx.", "").Replace(".nupkg", "")
-          # Write-Host "DacFx package version: $version"
-          # Write-Host "##vso[task.setvariable variable=dacFxPackageVersion]$version
+          # Parse the nupkg file name for the version number
+          $filename = Split-Path $files[0] -leaf
+          $version = $filename.Replace("Microsoft.SqlServer.DacFx.", "").Replace(".nupkg", "")
+          Write-Host "DacFx package version: $version"
+          Write-Host "##vso[task.setvariable variable=dacFxPackageVersion]$version"
 
     - template: 'template-steps-build-test.yml'
       parameters:

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -54,22 +54,22 @@ stages:
     - script: 'dotnet nuget add source "$(dacFxPackagePath)"'
       displayName: 'Nuget Add Source to Path Containing DacFx Package'
 
-    # Find the nupkg file inside dacFxPackagePath and parse it for the version
-    - bash: |
-        pattern="$(dacFxPackagePath)/$(dacFxPackagePattern)"
-        files=( $pattern )
-        nupkgFile=${files[0]}
-        if test -f $nupkgFile; then
-          echo "DacFx package found: $nupkgFile"
-        else
-          exit 1
-        fi
-        version=${nupkgFile/"$(dacFxPackagePath)/Microsoft.SqlServer.DacFx."/""}
-        version=${version/".nupkg"/""}
-        echo "DacFx package version: $version"
-        echo "##vso[task.setvariable variable=dacFxPackageVersion]$version"
+    - task: PowerShell@2
       displayName: 'Extract Version from DacFx nupkg file'
       failOnStderr: true
+      targetType: 'inline'
+      script: |
+        # Locate the nupkg file from the package path
+        $files =  Get-ChildItem "$(dacFxPackagePath)" -Recurse -Include "$(dacFxPackagePattern)"
+        if ($files.length -ne 1) {
+          Write-Error "Failed to find Nuget package with pattern $(dacFxPackagePattern) in $(dacFxPackagePath)"
+        }
+
+        # Parse the nupkg file name for the version number
+        $filename = Split-Path $files[0] -leaf
+        $version = $filename.Replace("Microsoft.SqlServer.DacFx.", "").Replace(".nupkg", "")
+        Write-Host "DacFx package version: $version"
+        Write-Host "##vso[task.setvariable variable=dacFxPackageVersion]$version
 
     - template: 'template-steps-build-test.yml'
       parameters:
@@ -77,4 +77,4 @@ stages:
         configuration: '$(configuration)'
         nugetVersion: '1.0.0'
         runCodeSign: 'false'
-        dacFxPackageVersion: '$(dacFxPackageVersion)'
+        dacFxPackageVersionArgument: '-p:DacFxPackageVersion="$(dacFxPackageVersion)"'

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -66,7 +66,7 @@ stages:
         fi
         version=${nupkgFile/"*Microsoft.SqlServer.DacFx."/""}
         version=${version/".nupkg"/""}
-        echo "##vso[task.setvariable variable=dacFxPackageVersion]version"
+        echo "##vso[task.setvariable variable=dacFxPackageVersion]$version"
       displayName: 'Extract Version from DacFx nupkg file'
       failOnStderr: true
 

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -2,21 +2,18 @@ trigger: none
 
 pr: none
 
-variables:
-  solution: '**/*.sln'
-  configuration: 'Debug'
-  azureSourcePipelineName: ''  # Set in Azure pipeline
-  azureSourcePipelineId: ''    # Set in Azure pipeline
-  azureProjectId: ''           # Set in Azure pipeline
-  dacFxPackagePattern: 'Microsoft.SqlServer.DacFx*-preview.nupkg'
-  dacFxPackagePath: '$(Pipeline.Workspace)/pkg'  # DacFx nupkg will be downloaded from nightly build and placed here
-
 # Pipeline trigger - this pipeline will run whenever the 'DacFx Nuget - Nightly' pipeline finishes
 resources:
   pipelines:
   - pipeline: 'github-build-test-nightly'
     source: 'DacFx Nuget - Nightly'
     trigger: true
+
+variables:
+  solution: '**/*.sln'
+  configuration: 'Debug'
+  dacFxPackagePattern: 'Microsoft.SqlServer.DacFx*-preview.nupkg'
+  dacFxPackagePath: '$(Pipeline.Workspace)/pkg'  # DacFx nupkg will be downloaded from nightly build and placed here
 
 stages:
 - stage: Build

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -5,13 +5,15 @@ pr: none
 # Pipeline trigger - this pipeline will run whenever the 'DacFx Nuget - Nightly' pipeline finishes
 resources:
   pipelines:
-  - pipeline: 'build-test-nightly'
+  - pipeline: 'github-build-test-nightly'
     source: '$(source-pipeline-name)'
     trigger: true
 
 variables:
   solution: '**/*.sln'
   configuration: 'Debug'
+  dacFxPackagePattern: 'Microsoft.SqlServer.DacFx*-preview.nupkg'
+  dacFxPackagePath: '$(Pipeline.Workspace)/pkg'  # DacFx nupkg will be downloaded from nightly build and placed here
 
 stages:
 - stage: Build
@@ -41,11 +43,26 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: 'Download Pipeline Artifact'
       inputs:
-        buildType: specific
+        buildType: 'specific'
         project: '$(ado-project-id)'
         definition: '$(source-pipeline-id)'
-        artifactName: drop
-        itemPattern: 'Microsoft.SqlServer.DacFx.*-preview.nupkg'
+        buildVersionToDownload: 'latest'
+        artifactName: 'drop'
+        itemPattern: '$(dacFxPackagePattern)'
+        targetPath: '$(dacFxPackagePath)'
+    
+    - script: 'dotnet nuget add source "$(dacFxPackagePath)"'
+      displayName: 'Nuget Add Source to Path Containing DacFx Package'
+
+    # Find the nupkg file inside dacFxPackagePath and parse it for the version
+    - bash: |
+        pattern="$(dacFxPackagePath)/$(dacFxPackagePattern)"
+        files=( $pattern )
+        echo "DacFx package found: ${files[0]}"
+        version=${${files[0]}/"*Microsoft.SqlServer.DacFx."/""}
+        version=${version/".nupkg"/""}
+        echo "##vso[task.setvariable variable=dacFxPackageVersion]version"
+      displayName: 'Extract Version from DacFx nupkg file'
 
     - template: 'template-steps-build-test.yml'
       parameters:
@@ -53,4 +70,4 @@ stages:
         configuration: '$(configuration)'
         nugetVersion: '1.0.0'
         runCodeSign: 'false'
-        
+        dacFxPackageVersion: '$(dacFxPackageVersion)'

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -66,11 +66,11 @@ stages:
             Write-Error "Failed to find Nuget package with pattern $(dacFxPackagePattern) in $(dacFxPackagePath)"
           }
 
-          # Parse the nupkg file name for the version number
-          $filename = Split-Path $files[0] -leaf
-          $version = $filename.Replace("Microsoft.SqlServer.DacFx.", "").Replace(".nupkg", "")
-          Write-Host "DacFx package version: $version"
-          Write-Host "##vso[task.setvariable variable=dacFxPackageVersion]$version
+          # # Parse the nupkg file name for the version number
+          # $filename = Split-Path $files[0] -leaf
+          # $version = $filename.Replace("Microsoft.SqlServer.DacFx.", "").Replace(".nupkg", "")
+          # Write-Host "DacFx package version: $version"
+          # Write-Host "##vso[task.setvariable variable=dacFxPackageVersion]$version
 
     - template: 'template-steps-build-test.yml'
       parameters:

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -56,20 +56,21 @@ stages:
 
     - task: PowerShell@2
       displayName: 'Extract Version from DacFx nupkg file'
-      failOnStderr: true
-      targetType: 'inline'
-      script: |
-        # Locate the nupkg file from the package path
-        $files =  Get-ChildItem "$(dacFxPackagePath)" -Recurse -Include "$(dacFxPackagePattern)"
-        if ($files.length -ne 1) {
-          Write-Error "Failed to find Nuget package with pattern $(dacFxPackagePattern) in $(dacFxPackagePath)"
-        }
+      inputs:
+        failOnStderr: true
+        targetType: 'inline'
+        script: |
+          # Locate the nupkg file from the package path
+          $files =  Get-ChildItem "$(dacFxPackagePath)" -Recurse -Include "$(dacFxPackagePattern)"
+          if ($files.length -ne 1) {
+            Write-Error "Failed to find Nuget package with pattern $(dacFxPackagePattern) in $(dacFxPackagePath)"
+          }
 
-        # Parse the nupkg file name for the version number
-        $filename = Split-Path $files[0] -leaf
-        $version = $filename.Replace("Microsoft.SqlServer.DacFx.", "").Replace(".nupkg", "")
-        Write-Host "DacFx package version: $version"
-        Write-Host "##vso[task.setvariable variable=dacFxPackageVersion]$version
+          # Parse the nupkg file name for the version number
+          $filename = Split-Path $files[0] -leaf
+          $version = $filename.Replace("Microsoft.SqlServer.DacFx.", "").Replace(".nupkg", "")
+          Write-Host "DacFx package version: $version"
+          Write-Host "##vso[task.setvariable variable=dacFxPackageVersion]$version
 
     - template: 'template-steps-build-test.yml'
       parameters:

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -64,10 +64,11 @@ stages:
         else
           exit 1
         fi
-        version=${$nupkgFile/"*Microsoft.SqlServer.DacFx."/""}
+        version=${nupkgFile/"*Microsoft.SqlServer.DacFx."/""}
         version=${version/".nupkg"/""}
         echo "##vso[task.setvariable variable=dacFxPackageVersion]version"
       displayName: 'Extract Version from DacFx nupkg file'
+      failOnStderr: true
 
     - template: 'template-steps-build-test.yml'
       parameters:

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -64,8 +64,9 @@ stages:
         else
           exit 1
         fi
-        version=${nupkgFile/"*Microsoft.SqlServer.DacFx."/""}
+        version=${nupkgFile/"$(dacFxPackagePath)/Microsoft.SqlServer.DacFx."/""}
         version=${version/".nupkg"/""}
+        echo "DacFx package version: $version"
         echo "##vso[task.setvariable variable=dacFxPackageVersion]$version"
       displayName: 'Extract Version from DacFx nupkg file'
       failOnStderr: true

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -17,7 +17,7 @@ variables:
 
 stages:
 - stage: Build
-  displayName: 'PR Validation'
+  displayName: 'Nightly Build Test'
 
   jobs:
   - job: BuildTest
@@ -48,7 +48,7 @@ stages:
         definition: '$(azureSourcePipelineId)'
         buildVersionToDownload: 'latest'
         artifactName: 'drop'
-        itemPattern: '$(dacFxPackagePattern)'
+        itemPattern: 'drop/$(dacFxPackagePattern)'
         targetPath: '$(dacFxPackagePath)'
     
     - script: 'dotnet nuget add source "$(dacFxPackagePath)"'

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -1,0 +1,56 @@
+trigger: none
+
+pr: none
+
+# Pipeline trigger - this pipeline will run whenever the 'DacFx Nuget - Nightly' pipeline finishes
+resources:
+  pipelines:
+  - pipeline: 'build-test-nightly'
+    source: '$(source-pipeline-name)'
+    trigger: true
+
+variables:
+  solution: '**/*.sln'
+  configuration: 'Debug'
+
+stages:
+- stage: Build
+  displayName: 'PR Validation'
+
+  jobs:
+  - job: BuildTest
+    displayName: 'Build and Test on'
+
+    # Verifies cross-platform build and test
+    strategy:
+      matrix:
+        linux:
+          imageName: 'ubuntu-latest'
+        mac:
+          imageName: 'macos-latest'
+        windows:
+          imageName: 'windows-latest'
+
+    pool:
+      vmImage: '$(imageName)'
+
+    workspace:
+      clean: all
+
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download Pipeline Artifact'
+      inputs:
+        buildType: specific
+        project: '$(ado-project-id)'
+        definition: '$(source-pipeline-id)'
+        artifactName: drop
+        itemPattern: 'Microsoft.SqlServer.DacFx.*-preview.nupkg'
+
+    - template: 'template-steps-build-test.yml'
+      parameters:
+        solution: '$(solution)'
+        configuration: '$(configuration)'
+        nugetVersion: '1.0.0'
+        runCodeSign: 'false'
+        

--- a/builds/build-test-nightly.yml
+++ b/builds/build-test-nightly.yml
@@ -58,8 +58,13 @@ stages:
     - bash: |
         pattern="$(dacFxPackagePath)/$(dacFxPackagePattern)"
         files=( $pattern )
-        echo "DacFx package found: ${files[0]}"
-        version=${${files[0]}/"*Microsoft.SqlServer.DacFx."/""}
+        nupkgFile=${files[0]}
+        if test -f $nupkgFile; then
+          echo "DacFx package found: $nupkgFile"
+        else
+          exit 1
+        fi
+        version=${$nupkgFile/"*Microsoft.SqlServer.DacFx."/""}
         version=${version/".nupkg"/""}
         echo "##vso[task.setvariable variable=dacFxPackageVersion]version"
       displayName: 'Extract Version from DacFx nupkg file'

--- a/builds/latest-nuget-build-test.yml
+++ b/builds/latest-nuget-build-test.yml
@@ -5,7 +5,7 @@ pr: none
 # Pipeline trigger - this pipeline will run whenever the 'DacFx Nuget - Nightly' pipeline finishes
 resources:
   pipelines:
-  - pipeline: 'github-build-test-nightly'
+  - pipeline: 'latest-nuget-build-test'
     source: 'DacFx Nuget - Nightly'
     trigger: true
 

--- a/builds/template-steps-build-test.yml
+++ b/builds/template-steps-build-test.yml
@@ -3,7 +3,7 @@ parameters:
   solution: ''
   nugetVersion: ''
   runCodeSign: ''
-  # This is mainly used for nightly tests to get version from nightly build
+  # This is mainly used for test pipelines to get version from Nuget build pipelines
   # The version defined in the csproj will be used when this is not set
   dacFxPackageVersionArgument: ''
 

--- a/builds/template-steps-build-test.yml
+++ b/builds/template-steps-build-test.yml
@@ -3,6 +3,9 @@ parameters:
   solution: ''
   nugetVersion: ''
   runCodeSign: ''
+  # dacFxPackageVersion is mainly used for nightly tests to get version from nightly build
+  # The version defined in the csproj will be used when this is not set
+  dacFxPackageVersion: ''
 
 steps:
 - task: UseDotNet@2
@@ -23,7 +26,7 @@ steps:
   inputs:
     command: build
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false'
+    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:DacFxPackageVersion="${{ parameters.dacFxPackageVersion }}"'
 
 # CodeSign is only run on release builds
 - task: UseDotNet@2

--- a/builds/template-steps-build-test.yml
+++ b/builds/template-steps-build-test.yml
@@ -3,9 +3,9 @@ parameters:
   solution: ''
   nugetVersion: ''
   runCodeSign: ''
-  # dacFxPackageVersion is mainly used for nightly tests to get version from nightly build
+  # This is mainly used for nightly tests to get version from nightly build
   # The version defined in the csproj will be used when this is not set
-  dacFxPackageVersion: ''
+  dacFxPackageVersionArgument: ''
 
 steps:
 - task: UseDotNet@2
@@ -26,7 +26,7 @@ steps:
   inputs:
     command: build
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:DacFxPackageVersion="${{ parameters.dacFxPackageVersion }}"'
+    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false ${{ parameters.dacFxPackageVersionArgument }}'
 
 # CodeSign is only run on release builds
 - task: UseDotNet@2

--- a/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
+++ b/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
@@ -9,8 +9,6 @@
 
     <!-- Path where all the DLLs build depends on will be copied to -->
     <BuildBinariesPath>$(MSBuildThisFileDirectory)\tools\netstandard2.1\</BuildBinariesPath>
-
-    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">160.5332.1-preview</DacFxPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
+++ b/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
@@ -9,10 +9,12 @@
 
     <!-- Path where all the DLLs build depends on will be copied to -->
     <BuildBinariesPath>$(MSBuildThisFileDirectory)\tools\netstandard2.1\</BuildBinariesPath>
+
+    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">160.5332.1-preview</DacFxPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="160.5332.1-preview" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="$(DacFxPackageVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" GeneratePathProperty="true" />
     <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" GeneratePathProperty="true" />
     <PackageReference Include="System.IO.Packaging" Version="5.0.0" GeneratePathProperty="true" />

--- a/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
+++ b/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <Target Name="CopyBuildBinaries" BeforeTargets="Build">
+    <Message Text="Using DacFx version '$(DacFxPackageVersion)'" Importance="high" />
     <ItemGroup>
       <NetCoreFiles Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\netstandard2.1\*.*" />
     </ItemGroup>

--- a/test/Microsoft.Buld.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
+++ b/test/Microsoft.Buld.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
@@ -6,8 +6,6 @@
 
     <!-- Location to save the SDK Nuget Package. This will also serve as the local Nuget source when testing the sqlproj build. -->
     <SdkPackagePath>$(MSBuildThisFileDirectory)pkg\</SdkPackagePath>
-
-    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">160.5332.1-preview</DacFxPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Buld.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
+++ b/test/Microsoft.Buld.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
@@ -6,6 +6,8 @@
 
     <!-- Location to save the SDK Nuget Package. This will also serve as the local Nuget source when testing the sqlproj build. -->
     <SdkPackagePath>$(MSBuildThisFileDirectory)pkg\</SdkPackagePath>
+
+    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">160.5332.1-preview</DacFxPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="16.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="160.5332.1-preview" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="$(DacFxPackageVersion)" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds a pipeline that downloads a nightly-built DacFx Nuget from [here](https://mssqltools.visualstudio.com/DacFx/_build?definitionId=524&_a=summary) (a simplified version of our release pipeline), then builds and tests the SDK against it. The schedule is configured in the source pipeline and should kick this one off when it finishes. 

The corresponding pipeline definition in ADO is here: https://mssqltools.visualstudio.com/DacFx/_build?definitionId=533