### PR TITLE
Exclude files specified as None from build

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -21,9 +21,10 @@
   </ItemGroup>
   
   <ItemGroup>
-    <!-- Remove files specified as PreDeploy and PostDeploy scripts from build -->
+    <!-- Remove files specified as PreDeploy, PostDeploy, and None scripts from build -->
     <Build Remove="@(PreDeploy)" />
     <Build Remove="@(PostDeploy)" />
+    <Build Remove="@(None)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Buld.Sql.Tests/BuildTestBase.cs
+++ b/test/Microsoft.Buld.Sql.Tests/BuildTestBase.cs
@@ -191,6 +191,14 @@ namespace Microsoft.Build.Sql.Tests
         }
 
         /// <summary>
+        /// Add scripts to the project that are not part of build. <paramref name="files"/> paths are relative.
+        /// </summary>
+        protected void AddNoneScripts(params string[] files)
+        {
+            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "None", files);
+        }
+
+        /// <summary>
         /// Add references to another project(s). <paramref name="projects"/> paths are relative.
         /// </summary>
         protected void AddProjectReference(params string[] projects)

--- a/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithNoneIncludeSqlFile/Table1.sql
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithNoneIncludeSqlFile/Table1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[Table1]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)

--- a/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithNoneIncludeSqlFile/Table2.sql
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/VerifyBuildWithNoneIncludeSqlFile/Table2.sql
@@ -1,0 +1,6 @@
+-- This file to be excluded from project by the test
+CREATE TABLE [dbo].[Table2]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)


### PR DESCRIPTION
Fixes #88 - SQL files specified as `<None Include=... />` are still included in build by the default globbing pattern. This change excludes them.