### PR TITLE
SDK default NetCoreBuild based on MsBuildRuntimeValue

### DIFF
--- a/src/Microsoft.Build.Sql/Microsoft.Build.Sql.nuspec
+++ b/src/Microsoft.Build.Sql/Microsoft.Build.Sql.nuspec
@@ -6,7 +6,9 @@
     <version>1.0.0</version>
     <title>Microsoft SQL Database Project Build SDK</title>
     <description>This package contains the SDK for building SQL Database Projects (.sqlproj) in .NET Core and .NET 5+.</description>
-    <packageType>MSBuildSDK</packageType>
+    <packageTypes>
+      <packageType name="MSBuildSDK" />
+    </packageTypes>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -6,8 +6,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <NetCoreBuild Condition="'NetCoreBuild' == '' And '$(MSBuildRuntimeType)' != 'Core'">False</NetCoreBuild>
-    <NetCoreBuild Condition="'NetCoreBuild' == '' And '$(MSBuildRuntimeType)' == 'Core'">True</NetCoreBuild>
+    <NetCoreBuild Condition="'$(NetCoreBuild)' == '' And '$(MSBuildRuntimeType)' == 'Core'">true</NetCoreBuild>
+    <NetCoreBuild Condition="'$(NetCoreBuild)' == '' And '$(MSBuildRuntimeType)' == 'Full'">false</NetCoreBuild>
     <NETCoreTargetsPath Condition="$(NETCoreTargetsPath) == ''">$(MSBuildThisFileDirectory)..\tools\netstandard2.1</NETCoreTargetsPath>
   </PropertyGroup>
 

--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -6,6 +6,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
+    <NetCoreBuild Condition="'NetCoreBuild' == '' And '$(MSBuildRuntimeType)' != 'Core'">False</NetCoreBuild>
+    <NetCoreBuild Condition="'NetCoreBuild' == '' And '$(MSBuildRuntimeType)' == 'Core'">True</NetCoreBuild>
     <NETCoreTargetsPath Condition="$(NETCoreTargetsPath) == ''">$(MSBuildThisFileDirectory)..\tools\netstandard2.1</NETCoreTargetsPath>
   </PropertyGroup>
 

--- a/test/Microsoft.Buld.Sql.Tests/BuildTestBase.cs
+++ b/test/Microsoft.Buld.Sql.Tests/BuildTestBase.cs
@@ -67,9 +67,6 @@ namespace Microsoft.Build.Sql.Tests
         /// <remarks>Adapted from Microsoft.VisualStudio.TeamSystem.Data.UnitTests.UTSqlTasks.ExecuteDotNetExe</remarks>
         protected int Build(out string stdOutput, out string stdError, string arguments = "")
         {
-            // Append NetCoreBuild to arguments
-            arguments += " /p:NetCoreBuild=true";
-
             // Set up the dotnet process
             ProcessStartInfo dotnetStartInfo = new ProcessStartInfo
             {


### PR DESCRIPTION
Sets NetCoreBuild value based on a [reserved property set by MSBuild](https://learn.microsoft.com/visualstudio/msbuild/msbuild-reserved-and-well-known-properties).

This simplifies build to just `dotnet build`

<html>
<body>
<!--StartFragment-->

MSBuildRuntimeType | Reserved | The type of the runtime that is currently executing. Introduced in MSBuild 15. Value may be undefined (prior to MSBuild 15), Full indicating that MSBuild is running on the desktop .NET Framework, Core indicating that MSBuild is running on .NET Core (for example in dotnet build), or Mono indicating that MSBuild is running on Mono.
-- | -- | --


<!--EndFragment-->
</body>
</html>

Thank you @pvanhouten for the idea in https://github.com/microsoft/DacFx/issues/80#issuecomment-1126550057