### PR TITLE
Support dotnet pack

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -11,7 +11,8 @@
     <NETCoreTargetsPath Condition="$(NETCoreTargetsPath) == ''">$(MSBuildThisFileDirectory)..\tools\netstandard2.1</NETCoreTargetsPath>
 
     <!-- Pack target properties -->
-    <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">tools</BuildOutputTargetFolder>
+    <PackageType Condition="'$(PackageType)' == ''">DACPAC</PackageType>
+    <IsTool Condition="'$(BuildOutputTargetFolder)' == ''">true</IsTool>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder); .dacpac</AllowedOutputExtensionsInPackageBuildOutputFolder>
     
     <!-- Suppress NU5128 since SQL NuGet Packages have no target framework dependencies -->

--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -9,14 +9,6 @@
     <NetCoreBuild Condition="'$(NetCoreBuild)' == '' And '$(MSBuildRuntimeType)' == 'Core'">true</NetCoreBuild>
     <NetCoreBuild Condition="'$(NetCoreBuild)' == '' And '$(MSBuildRuntimeType)' == 'Full'">false</NetCoreBuild>
     <NETCoreTargetsPath Condition="$(NETCoreTargetsPath) == ''">$(MSBuildThisFileDirectory)..\tools\netstandard2.1</NETCoreTargetsPath>
-
-    <!-- Pack target properties -->
-    <PackageType Condition="'$(PackageType)' == ''">DACPAC</PackageType>
-    <IsTool Condition="'$(BuildOutputTargetFolder)' == ''">true</IsTool>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder); .dacpac</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    
-    <!-- Suppress NU5128 since SQL NuGet Packages have no target framework dependencies -->
-    <NoWarn>NU5128</NoWarn>
   </PropertyGroup>
 
   <!-- Defaults from SSDT -->

--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -13,6 +13,9 @@
     <!-- Pack target properties -->
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">tools</BuildOutputTargetFolder>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder); .dacpac</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    
+    <!-- Suppress NU5128 since SQL NuGet Packages have no target framework dependencies -->
+    <NoWarn>NU5128</NoWarn>
   </PropertyGroup>
 
   <!-- Defaults from SSDT -->

--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -9,6 +9,10 @@
     <NetCoreBuild Condition="'$(NetCoreBuild)' == '' And '$(MSBuildRuntimeType)' == 'Core'">true</NetCoreBuild>
     <NetCoreBuild Condition="'$(NetCoreBuild)' == '' And '$(MSBuildRuntimeType)' == 'Full'">false</NetCoreBuild>
     <NETCoreTargetsPath Condition="$(NETCoreTargetsPath) == ''">$(MSBuildThisFileDirectory)..\tools\netstandard2.1</NETCoreTargetsPath>
+
+    <!-- Pack target properties -->
+    <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">tools</BuildOutputTargetFolder>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder); .dacpac</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <!-- Defaults from SSDT -->

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -11,7 +11,7 @@
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   
-  <!-- Import Nuget pack target -->
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/targets/Microsoft.NET.DefaultAssemblyInfo.targets" />
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets" />
 
   <!-- Add dacpac file BuiltProjectOutputGroupOutput, so that it will get included in the NuGet package by the Pack target -->

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -4,6 +4,16 @@
   Licensed under the MIT license.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <!-- Pack target properties -->
+  <PropertyGroup>
+    <PackageType>$(PackageType);DACPAC</PackageType>
+    <IsTool Condition="'$(IsTool)' == ''">true</IsTool>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.dacpac</AllowedOutputExtensionsInPackageBuildOutputFolder>
+
+    <!-- Suppress NU5128 since SQL NuGet Packages have no target framework dependencies -->
+    <NoWarn>$(NoWarn),NU5128</NoWarn>
+  </PropertyGroup>
 
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -11,6 +11,16 @@
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   
+  <!-- Import Nuget pack target -->
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets" />
+
+  <!-- Add dacpac file BuiltProjectOutputGroupOutput, so that it will get included in the NuGet package by the Pack target -->
+  <Target Name="AddDacpacToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup">
+    <ItemGroup>
+      <BuiltProjectOutputGroupOutput Include="$(SqlTargetPath)" TargetPath="$(SqlTargetFile)" FinalOutputPath="$(SqlTargetPath)" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <!-- This is necessary for building on non-Windows platforms. -->
     <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />

--- a/test/Microsoft.Buld.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Buld.Sql.Tests/BuildTests.cs
@@ -11,14 +11,14 @@ using NUnit.Framework;
 namespace Microsoft.Build.Sql.Tests
 {
     [TestFixture]
-    public class BuildTests : BuildTestBase
+    public class BuildTests : DotnetTestBase
     {
         [Test]
         [Description("Verifies simple build with default settings.")]
         public void SuccessfulSimpleBuild()
         {
             string stdOutput, stdError;
-            int exitCode = this.Build(out stdOutput, out stdError);
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
@@ -33,7 +33,7 @@ namespace Microsoft.Build.Sql.Tests
             this.AddPreDeployScripts("Script.PreDeployment1.sql");
 
             string stdOutput, stdError;
-            int exitCode = this.Build(out stdOutput, out stdError);
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
@@ -48,7 +48,7 @@ namespace Microsoft.Build.Sql.Tests
             this.AddPostDeployScripts("Script.PostDeployment1.sql");
 
             string stdOutput, stdError;
-            int exitCode = this.Build(out stdOutput, out stdError);
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
@@ -63,7 +63,7 @@ namespace Microsoft.Build.Sql.Tests
             this.RemoveBuildFiles("Table2.sql");
 
             string stdOutput, stdError;
-            int exitCode = this.Build(out stdOutput, out stdError);
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
@@ -101,7 +101,7 @@ namespace Microsoft.Build.Sql.Tests
             this.AddBuildFiles(tempFile);
 
             string stdOutput, stdError;
-            int exitCode = this.Build(out stdOutput, out stdError);
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
@@ -132,7 +132,7 @@ namespace Microsoft.Build.Sql.Tests
         public void VerifyBuildFailureWithUnresolvedReference()
         {
             string stdOutput, stdError;
-            int exitCode = this.Build(out stdOutput, out stdError);
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
 
             // Verify failure
             Assert.AreEqual(1, exitCode, "Build is expected to fail.");
@@ -150,7 +150,7 @@ namespace Microsoft.Build.Sql.Tests
             this.AddProjectReference(Path.Combine(tempFolder, "ReferenceProj.sqlproj"));
 
             string stdOutput, stdError;
-            int exitCode = this.Build(out stdOutput, out stdError);
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
@@ -170,7 +170,7 @@ namespace Microsoft.Build.Sql.Tests
             this.RemoveBuildFiles("ReferenceProj/**/*.*");
 
             string stdOutput, stdError;
-            int exitCode = this.Build(out stdOutput, out stdError);
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
@@ -186,7 +186,7 @@ namespace Microsoft.Build.Sql.Tests
             this.AddNoneScripts("Table2.sql");
 
             string stdOutput, stdError;
-            int exitCode = this.Build(out stdOutput, out stdError);
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);

--- a/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
@@ -10,9 +10,9 @@ using NUnit.Framework;
 
 namespace Microsoft.Build.Sql.Tests
 {
-    public abstract class BuildTestBase
+    public abstract class DotnetTestBase
     {
-        private const string DatabaseProjectName = "project";
+        protected const string DatabaseProjectName = "project";
 
 #if DEBUG
         protected const bool IsDebug = true;
@@ -56,22 +56,23 @@ namespace Microsoft.Build.Sql.Tests
             TestUtils.CopyDirectoryRecursive("../../../Template", this.WorkingDirectory);
 
             // Copy test specific files to WorkingDirectory
-            TestUtils.CopyDirectoryRecursive(this.TestDataDirectory, this.WorkingDirectory);
+            if (Directory.Exists(this.TestDataDirectory))
+            {
+                TestUtils.CopyDirectoryRecursive(this.TestDataDirectory, this.WorkingDirectory);
+            }
         }
 
         /// <summary>
-        /// Calls dotnet build to build the project.
+        /// Calls dotnet command on the database project.
         /// </summary>
         /// <param name="arguments">Any additional arguments to be passed to 'dotnet build'.</param>
         /// <returns>The Exit Code of the dotnet process.</returns>
-        /// <remarks>Adapted from Microsoft.VisualStudio.TeamSystem.Data.UnitTests.UTSqlTasks.ExecuteDotNetExe</remarks>
-        protected int Build(out string stdOutput, out string stdError, string arguments = "")
+        protected int RunDotnetCommand(string dotnetCommand, out string stdOutput, out string stdError, string arguments = "")
         {
-            // Set up the dotnet process
             ProcessStartInfo dotnetStartInfo = new ProcessStartInfo
             {
                 FileName = TestUtils.GetDotnetPath(),
-                Arguments = $"build {DatabaseProjectName}.sqlproj {arguments}",
+                Arguments = $"{dotnetCommand} {DatabaseProjectName}.sqlproj {arguments}",
                 WorkingDirectory = this.WorkingDirectory,
                 WindowStyle = ProcessWindowStyle.Hidden,
                 RedirectStandardOutput = true,
@@ -81,6 +82,16 @@ namespace Microsoft.Build.Sql.Tests
                 // This also requires the full path of the dotnet process be passed to FileName.
             };
 
+            return ExecuteProcessWithOutput(dotnetStartInfo, out stdOutput, out stdError);
+        }
+
+        /// <summary>
+        /// Runs a process based on <paramref name="startInfo"/>
+        /// </summary>
+        /// <returns>The Exit Code of the process.</returns>
+        /// <remarks>Adapted from Microsoft.VisualStudio.TeamSystem.Data.UnitTests.UTSqlTasks.ExecuteDotNetExe</remarks>
+        private int ExecuteProcessWithOutput(ProcessStartInfo startInfo, out string stdOutput, out string stdError)
+        {
             // Setup build output and error handlers
             object threadSharedLock = new object();
             StringBuilder threadShared_ReceivedOutput = new StringBuilder();
@@ -90,7 +101,7 @@ namespace Microsoft.Build.Sql.Tests
             int interlocked_errorsCompleted = 0;
 
             using Process dotnet = new Process();
-            dotnet.StartInfo = dotnetStartInfo;
+            dotnet.StartInfo = startInfo;
 
             // the OutputDataReceived delegateis called on a separate thread as output data arrives from the process
             dotnet.OutputDataReceived += (sender, e) =>
@@ -128,7 +139,7 @@ namespace Microsoft.Build.Sql.Tests
             };
 
             // Start the build and begin reading the outputs
-            TestContext.WriteLine($"Executing {dotnetStartInfo.FileName} {dotnetStartInfo.Arguments} in {dotnetStartInfo.WorkingDirectory}");
+            TestContext.WriteLine($"Executing {startInfo.FileName} {startInfo.Arguments} in {startInfo.WorkingDirectory}");
             dotnet.Start();
             dotnet.BeginOutputReadLine();
             dotnet.BeginErrorReadLine();
@@ -216,8 +227,16 @@ namespace Microsoft.Build.Sql.Tests
         /// </summary>
         protected string GetDacpacPath()
         {
+            return Path.Combine(this.GetOutputDirectory(), DatabaseProjectName + ".dacpac");
+        }
+
+        /// <summary>
+        /// Returns the output directory. Ex: /bin/Debug/
+        /// </summary>
+        protected string GetOutputDirectory()
+        {
             string configuration = IsDebug ? "Debug" : "Release";
-            return Path.Combine(this.WorkingDirectory, "bin", configuration, DatabaseProjectName + ".dacpac");
+            return Path.Combine(this.WorkingDirectory, "bin", configuration);
         }
 
         /// <summary>

--- a/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using Microsoft.Build.Construction;
 using Microsoft.SqlServer.Dac;
 using NUnit.Framework;
 

--- a/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using Microsoft.Build.Construction;
 using Microsoft.SqlServer.Dac;
 using NUnit.Framework;
 
@@ -82,16 +83,6 @@ namespace Microsoft.Build.Sql.Tests
                 // This also requires the full path of the dotnet process be passed to FileName.
             };
 
-            return ExecuteProcessWithOutput(dotnetStartInfo, out stdOutput, out stdError);
-        }
-
-        /// <summary>
-        /// Runs a process based on <paramref name="startInfo"/>
-        /// </summary>
-        /// <returns>The Exit Code of the process.</returns>
-        /// <remarks>Adapted from Microsoft.VisualStudio.TeamSystem.Data.UnitTests.UTSqlTasks.ExecuteDotNetExe</remarks>
-        private int ExecuteProcessWithOutput(ProcessStartInfo startInfo, out string stdOutput, out string stdError)
-        {
             // Setup build output and error handlers
             object threadSharedLock = new object();
             StringBuilder threadShared_ReceivedOutput = new StringBuilder();
@@ -101,7 +92,7 @@ namespace Microsoft.Build.Sql.Tests
             int interlocked_errorsCompleted = 0;
 
             using Process dotnet = new Process();
-            dotnet.StartInfo = startInfo;
+            dotnet.StartInfo = dotnetStartInfo;
 
             // the OutputDataReceived delegateis called on a separate thread as output data arrives from the process
             dotnet.OutputDataReceived += (sender, e) =>
@@ -139,7 +130,7 @@ namespace Microsoft.Build.Sql.Tests
             };
 
             // Start the build and begin reading the outputs
-            TestContext.WriteLine($"Executing {startInfo.FileName} {startInfo.Arguments} in {startInfo.WorkingDirectory}");
+            TestContext.WriteLine($"Executing {dotnetStartInfo.FileName} {dotnetStartInfo.Arguments} in {dotnetStartInfo.WorkingDirectory}");
             dotnet.Start();
             dotnet.BeginOutputReadLine();
             dotnet.BeginErrorReadLine();

--- a/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Build.Sql.Tests
         /// <summary>
         /// Calls dotnet command on the database project.
         /// </summary>
+        /// <param name="dotnetCommand">The dotnet command to run (build, pack, etc.)</param>
         /// <param name="arguments">Any additional arguments to be passed to 'dotnet build'.</param>
         /// <returns>The Exit Code of the dotnet process.</returns>
         protected int RunDotnetCommand(string dotnetCommand, out string stdOutput, out string stdError, string arguments = "")

--- a/test/Microsoft.Buld.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
+++ b/test/Microsoft.Buld.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
@@ -37,8 +37,4 @@
     <None Remove="$(SdkPackagePath)\**" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="TestData\SuccessfulPackWithCustomPropereties\" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.Buld.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
+++ b/test/Microsoft.Buld.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Build" Version="16.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="$(DacFxPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging" Version="6.3.1" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>
@@ -34,6 +35,10 @@
 
   <ItemGroup>
     <None Remove="$(SdkPackagePath)\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="TestData\SuccessfulPackWithCustomPropereties\" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Buld.Sql.Tests/PackTests.cs
+++ b/test/Microsoft.Buld.Sql.Tests/PackTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NuGet.Packaging;
@@ -48,40 +49,76 @@ namespace Microsoft.Build.Sql.Tests
         [Description("Verifies pack with custom defined properties.")]
         public void SuccessfulPackWithCustomProperties()
         {
-            // The project file in this test has a bunch of custom properties
+            // Populate project file with custom properties: https://learn.microsoft.com/nuget/reference/msbuild-targets#pack-target
+            string customPackageId = "MyCustomPackageId";
+            string customPackageVersion = "3.4.5-test";
+            var properties = new List<(string NuspecAttributeName, string MSBuildPropertyName, string Value)>()
+            {
+                ("Id", "PackageId", customPackageId),
+                ("Version", "PackageVersion", customPackageVersion),
+                ("Authors", "Authors", "MyCustomAuthors"),
+                ("Title", "Title", "MyCustomTitle"),
+                ("Description", "Description", "My custom description"),
+                ("Copyright", "Copyright", "My custom copyright"),
+                ("RequireLicenseAcceptance", "PackageRequireLicenseAcceptance", "true"),
+                ("license", "PackageLicenseExpression", "MIT"),
+                ("PackageType", "PackageType", "MyCustomPackageType")   // This one is a collection
+            };
+
+            ProjectUtils.AddProperties(this.GetProjectFilePath(), 
+                properties.Select(p => new KeyValuePair<string, string>(p.MSBuildPropertyName, p.Value)));
+
+            // Pack
             string stdOutput, stdError;
             int exitCode = this.RunDotnetCommand("pack", out stdOutput, out stdError);
 
-            // Verify success
+            // Verify
             Assert.AreEqual(0, exitCode, "Pack failed with error " + stdError);
             Assert.AreEqual(string.Empty, stdError);
             this.VerifyDacPackage();
-            this.VerifyNugetPackage("", (PackageArchiveReader package) => {
-                // TODO
+            this.VerifyNugetPackage($"{customPackageId}.{customPackageVersion}.nupkg", (PackageArchiveReader package) => {
+                // Verify every custom property is set correctly in the nuspec
+                foreach (var property in properties)
+                {
+                    if (property.NuspecAttributeName.Equals("PackageType"))
+                    {
+                        // PackageType is a collection, so we verify our custom type is one of the items
+                        Assert.IsTrue(package.GetPackageTypes().Any(t => t.Name.Equals(property.Value, StringComparison.OrdinalIgnoreCase)),
+                            $"Expected '{property.Value}' to be one of the package types.");
+                    }
+                    else
+                    {
+                        Assert.AreEqual(property.Value, package.NuspecReader.GetMetadataValue(property.NuspecAttributeName),
+                            $"Difference found in nuspec attribute '{property.NuspecAttributeName}'");
+                    }
+                }
             });
         }
 
-        private string GetDefaultNugetPackagePath(string packageNameOverride = "")
-        {
-            string packageName = String.IsNullOrEmpty(packageNameOverride) ? $"{DatabaseProjectName}.1.0.0.nupkg" : packageNameOverride;
-            return Path.Combine(this.GetOutputDirectory(), packageName);
-        }
-
+        /// <summary>
+        /// Verifies Nuget package created by dotnet pack command. Checks for nupkg in bin/configration folder.
+        /// Verifies DACPAC is in the /tools folder within the nupkg, and verifies DACPAC is one of its package types.
+        /// </summary>
+        /// <param name="packageNameOverride">When not set, defaults to Name.Version.nupkg</param>
+        /// <param name="test">Additional test to run against the package</param>
         private void VerifyNugetPackage(string packageNameOverride = "", Action<PackageArchiveReader>? test = null)
         {
             // Verify packakge exists
-            string packagePath = this.GetDefaultNugetPackagePath();
+            string packageName = String.IsNullOrEmpty(packageNameOverride) ? $"{DatabaseProjectName}.1.0.0.nupkg" : packageNameOverride;
+            string packagePath = Path.Combine(this.GetOutputDirectory(), packageName);
             Assert.IsTrue(File.Exists(packagePath), $"Nuget package not found: {packagePath}");
 
             using var packageReader = new PackageArchiveReader(packagePath);
 
             // Verify dacpac is in tools folder
             var files = packageReader.GetFiles();
-            Assert.IsTrue(files.Any(f => f.Equals($"tools/{DatabaseProjectName}.dacpac", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(files.Any(f => f.Equals($"tools/{DatabaseProjectName}.dacpac", StringComparison.OrdinalIgnoreCase)),
+                $"Expected 'tools/{DatabaseProjectName}.dacpac' to be in the Nuget package.");
 
             // Verify the DACPAC package type is set
             var packageTypes = packageReader.GetPackageTypes();
-            Assert.IsTrue(packageTypes.Any(t => t.Name.Equals("DACPAC", StringComparison.OrdinalIgnoreCase)));
+            Assert.IsTrue(packageTypes.Any(t => t.Name.Equals("DACPAC", StringComparison.OrdinalIgnoreCase)),
+                "Expected 'DACPAC' to be one of the package types.");
 
             // Run additional test on the package
             test?.Invoke(packageReader);

--- a/test/Microsoft.Buld.Sql.Tests/PackTests.cs
+++ b/test/Microsoft.Buld.Sql.Tests/PackTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using Microsoft.Build.Construction;
 using NuGet.Packaging;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace Microsoft.Build.Sql.Tests
 {
@@ -30,7 +29,7 @@ namespace Microsoft.Build.Sql.Tests
         }
 
         [Test]
-        [Description("Verifies packing separately after builid.")]
+        [Description("Verifies packing separately after build.")]
         public void VerifyPackWithNoBuild()
         {
             // Run build first

--- a/test/Microsoft.Buld.Sql.Tests/PackTests.cs
+++ b/test/Microsoft.Buld.Sql.Tests/PackTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using NuGet.Packaging;
+using NUnit.Framework;
+
+namespace Microsoft.Build.Sql.Tests
+{
+    [TestFixture]
+    public class PackTests : DotnetTestBase
+    {
+        [Test]
+        [Description("Verifies pack with default settings.")]
+        public void SuccessfulSimplePack()
+        {
+            string stdOutput, stdError;
+            int exitCode = this.RunDotnetCommand("pack", out stdOutput, out stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Pack failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+            this.VerifyNugetPackage();
+        }
+
+        [Test]
+        [Description("Verifies packing separately after builid.")]
+        public void SuccessfulPackWithNoBuild()
+        {
+            // Run build first
+            string stdOutput, stdError;
+            int exitCode = this.RunDotnetCommand("build", out stdOutput, out stdError);
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Run pack with --no-build
+            exitCode = this.RunDotnetCommand("pack", out stdOutput, out stdError, "--no-build");
+            Assert.AreEqual(0, exitCode, "Pack failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyNugetPackage();
+        }
+
+        [Test]
+        [Description("Verifies pack with custom defined properties.")]
+        public void SuccessfulPackWithCustomProperties()
+        {
+            // The project file in this test has a bunch of custom properties
+            string stdOutput, stdError;
+            int exitCode = this.RunDotnetCommand("pack", out stdOutput, out stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Pack failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+            this.VerifyNugetPackage("", (PackageArchiveReader package) => {
+                // TODO
+            });
+        }
+
+        private string GetDefaultNugetPackagePath(string packageNameOverride = "")
+        {
+            string packageName = String.IsNullOrEmpty(packageNameOverride) ? $"{DatabaseProjectName}.1.0.0.nupkg" : packageNameOverride;
+            return Path.Combine(this.GetOutputDirectory(), packageName);
+        }
+
+        private void VerifyNugetPackage(string packageNameOverride = "", Action<PackageArchiveReader>? test = null)
+        {
+            // Verify packakge exists
+            string packagePath = this.GetDefaultNugetPackagePath();
+            Assert.IsTrue(File.Exists(packagePath), $"Nuget package not found: {packagePath}");
+
+            using var packageReader = new PackageArchiveReader(packagePath);
+
+            // Verify dacpac is in tools folder
+            var files = packageReader.GetFiles();
+            Assert.IsTrue(files.Any(f => f.Equals($"tools/{DatabaseProjectName}.dacpac", StringComparison.OrdinalIgnoreCase)));
+
+            // Verify the DACPAC package type is set
+            var packageTypes = packageReader.GetPackageTypes();
+            Assert.IsTrue(packageTypes.Any(t => t.Name.Equals("DACPAC", StringComparison.OrdinalIgnoreCase)));
+
+            // Run additional test on the package
+            test?.Invoke(packageReader);
+        }
+    }
+}

--- a/test/Microsoft.Buld.Sql.Tests/ProjectUtils.cs
+++ b/test/Microsoft.Buld.Sql.Tests/ProjectUtils.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Build.Sql.Tests
@@ -38,7 +39,8 @@ namespace Microsoft.Build.Sql.Tests
         ///     ...
         ///   </ItemGroup>
         /// </summary>
-        public static void AddItemGroup(string projectFilePath, string itemName, string[] filePaths)
+        /// <param name="addMetadata">Optional delegate to set metadata on each item added.</param>
+        public static void AddItemGroup(string projectFilePath, string itemName, string[] filePaths, Action<ProjectItemElement>? addMetadata = null)
         {
             if (filePaths != null && filePaths.Length > 0)
             {
@@ -49,7 +51,10 @@ namespace Microsoft.Build.Sql.Tests
                     ProjectItemGroupElement itemGroup = project.Xml.AddItemGroup();
                     foreach (string filePath in filePaths)
                     {
-                        itemGroup.AddItem(itemName, filePath);
+                        ProjectItemElement item = project.Xml.CreateItemElement(itemName);
+                        item.Include = filePath;
+                        itemGroup.AppendChild(item);
+                        addMetadata?.Invoke(item);
                     }
 
                     project.Save(project.FullPath);

--- a/test/Microsoft.Buld.Sql.Tests/ProjectUtils.cs
+++ b/test/Microsoft.Buld.Sql.Tests/ProjectUtils.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Build.Construction;
-using Microsoft.Build.Evaluation;
 using System;
 using System.Collections.Generic;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 
 namespace Microsoft.Build.Sql.Tests
 {
@@ -51,8 +51,7 @@ namespace Microsoft.Build.Sql.Tests
                     ProjectItemGroupElement itemGroup = project.Xml.AddItemGroup();
                     foreach (string filePath in filePaths)
                     {
-                        ProjectItemElement item = project.Xml.CreateItemElement(itemName);
-                        item.Include = filePath;
+                        ProjectItemElement item = project.Xml.CreateItemElement(itemName, filePath);
                         itemGroup.AppendChild(item);
                         addMetadata?.Invoke(item);
                     }

--- a/test/Microsoft.Buld.Sql.Tests/ProjectUtils.cs
+++ b/test/Microsoft.Buld.Sql.Tests/ProjectUtils.cs
@@ -3,11 +3,32 @@
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using System.Collections.Generic;
 
 namespace Microsoft.Build.Sql.Tests
 {
     public static class ProjectUtils
     {
+        /// <summary>
+        /// Adds a PropertyGroup to the project XML and populates it with <paramref name="properties"/>.
+        /// </summary>
+        public static void AddProperties(string projectFilePath, IEnumerable<KeyValuePair<string, string>> properties)
+        {
+            using (ProjectCollection projectCollection = GetNewEngine())
+            {
+                Project project = new Project(projectFilePath, null, "Current", projectCollection, ProjectLoadSettings.IgnoreMissingImports);
+
+                ProjectPropertyGroupElement propertyGroup = project.Xml.AddPropertyGroup();
+                foreach (KeyValuePair<string, string> property in properties)
+                {
+                    propertyGroup.AddProperty(property.Key, property.Value);
+                }
+
+                project.Save(project.FullPath);
+                projectCollection.UnloadAllProjects();
+            }
+        }
+
         /// <summary>
         /// Adds an ItemGroup to the project XML and populates it with <paramref name="itemName"/> and <paramref name="filePaths"/>.
         /// Result should look something like:

--- a/test/Microsoft.Buld.Sql.Tests/TestData/SuccessfulPackWithCustomProperties/project.sqlproj
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/SuccessfulPackWithCustomProperties/project.sqlproj
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
-  <PropertyGroup>
-    <Name>ReferenceProj</Name>
-    <DSP>Microsoft.Data.Tools.Schema.Sql.Sql150DatabaseSchemaProvider</DSP>
-    <ModelCollation>1033, CI</ModelCollation>
-  </PropertyGroup>
-</Project>

--- a/test/Microsoft.Buld.Sql.Tests/TestData/SuccessfulPackWithCustomProperties/project.sqlproj
+++ b/test/Microsoft.Buld.Sql.Tests/TestData/SuccessfulPackWithCustomProperties/project.sqlproj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build">
+  <Sdk Name="Microsoft.Build.Sql" Version="1.0.0" />
+  <PropertyGroup>
+    <Name>ReferenceProj</Name>
+    <DSP>Microsoft.Data.Tools.Schema.Sql.Sql150DatabaseSchemaProvider</DSP>
+    <ModelCollation>1033, CI</ModelCollation>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Run `dotnet pack` to create a Nuget package containing your DACPAC file.
- No nuspec file needed
- No changes to the project file needed (besides updating the SDK version to the release that will contain this PR)
- DACPAC file will be in the `tools` folder inside the package
- Package will be created to `/bin/debug/ProjectName.1.0.0.nupkg`, configure package ID and version with MSBuild properties: https://learn.microsoft.com/nuget/reference/msbuild-targets#pack-target
- Created package will have `DACPAC` as one of the package types
