### PR TITLE
Auto-version SDK template to build version

### DIFF
--- a/builds/template-steps-build-test.yml
+++ b/builds/template-steps-build-test.yml
@@ -106,7 +106,7 @@ steps:
     command: custom
     custom: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:NuspecProperties="version=${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:NuspecProperties="version=${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false -p:PackageVersion=${{ parameters.nugetVersion }}'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/src/Microsoft.Build.Sql.Templates/Microsoft.Build.Sql.Templates.csproj
+++ b/src/Microsoft.Build.Sql.Templates/Microsoft.Build.Sql.Templates.csproj
@@ -10,13 +10,56 @@
     <PackageProjectUrl>https://github.com/microsoft/dacfx</PackageProjectUrl>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <TemplateIntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\$(MSBuildThisFileName)\sqlproject</TemplateIntermediateOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="**\*" />
+    <Compile Remove="**/*" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="sqlproject\**" PackagePath="content/" />
+    <Content Include="$(TemplateIntermediateOutputPath)\**" PackagePath="content/" Pack="true" />
   </ItemGroup>
+
+  <Target Name="CleanIntermediateFolder" AfterTargets="Clean">
+    <RemoveDir Directories="$(TemplateIntermediateOutputPath)" />
+  </Target>
+
+  <!-- This target copies template files to intermediate output path, then sets the SDK version to the current assembly version -->
+  <Target Name="CopyTemplateFiles" BeforeTargets="GenerateNuspec;Build">
+    <ItemGroup>
+      <TemplateFiles Include="sqlproject/**" />
+    </ItemGroup>
+    <Copy SourceFiles="@(TemplateFiles)" DestinationFiles="$(TemplateIntermediateOutputPath)/%(RecursiveDir)%(Filename)%(Extension)" />
+    <ReplaceFileText 
+      InputFilename="$(TemplateIntermediateOutputPath)/SqlProject1.sqlproj"
+      OutputFilename="$(TemplateIntermediateOutputPath)/SqlProject1.sqlproj" 
+      MatchExpression="###ASSEMBLY_VERSION###"
+      ReplacementText="$(PackageVersion)" />
+    <ItemGroup>
+      <Content Include="$(TemplateIntermediateOutputPath)\**" PackagePath="content/" Pack="true" />
+    </ItemGroup>
+  </Target>
+
+  <UsingTask TaskName="ReplaceFileText" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)/Microsoft.Build.Tasks.Core.dll" >
+    <ParameterGroup>
+      <InputFilename ParameterType="System.String" Required="true" />
+      <OutputFilename ParameterType="System.String" Required="true" />
+      <MatchExpression ParameterType="System.String" Required="true" />
+      <ReplacementText ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+              File.WriteAllText(
+                  OutputFilename,
+                  Regex.Replace(File.ReadAllText(InputFilename), MatchExpression, ReplacementText)
+                  );
+            ]]>
+      </Code>
+    </Task>
+  </UsingTask>
 
 </Project>

--- a/src/Microsoft.Build.Sql.Templates/Microsoft.Build.Sql.Templates.csproj
+++ b/src/Microsoft.Build.Sql.Templates/Microsoft.Build.Sql.Templates.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="**/*" />
+    <Compile Remove="**\*" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(TemplateIntermediateOutputPath)\**" PackagePath="content/" Pack="true" />

--- a/src/Microsoft.Build.Sql.Templates/sqlproject/SqlProject1.sqlproj
+++ b/src/Microsoft.Build.Sql.Templates/sqlproject/SqlProject1.sqlproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build">
-  <Sdk Name="Microsoft.Build.Sql" Version="0.1.3-preview" />
+  <Sdk Name="Microsoft.Build.Sql" Version="###ASSEMBLY_VERSION###" />
   <PropertyGroup>
     <Name>SqlProject1</Name>
     <DSP>Microsoft.Data.Tools.Schema.Sql.{TargetPlatform}DatabaseSchemaProvider</DSP>

--- a/test/Microsoft.Buld.Sql.Tests/ProjectUtils.cs
+++ b/test/Microsoft.Buld.Sql.Tests/ProjectUtils.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Build.Sql.Tests
             string dspValue = "";
             // parse file xml to <DSP> element in <Project> root element
             XDocument sqlproj = XDocument.Load(projectFilePath);
-            XElement dsp = sqlproj.Root.Element("PropertyGroup").Element("DSP");
+            XElement? dsp = sqlproj.Root?.Element("PropertyGroup")?.Element("DSP");
             if (dsp != null)
             {
                 dspValue = dsp.Value;


### PR DESCRIPTION
This sets the SDK version in the template to be the assembly version, so when we generate templates package version 1.2.3, the SDK version when you do `dotnet new sqlproj` is 1.2.3