### PR TITLE
Clean up test runs

### DIFF
--- a/builds/template-steps-build-test.yml
+++ b/builds/template-steps-build-test.yml
@@ -109,10 +109,37 @@ steps:
     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:NuspecProperties="version=${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false -p:PackageVersion=${{ parameters.nugetVersion }}'
 
 - task: DotNetCoreCLI@2
-  displayName: '.NET Test'
+  displayName: '.NET Test for .NET Core 3.1'
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }}'
+    arguments: '--configuration ${{ parameters.configuration }} -f netcoreapp3.1'
+  env:
+    DOTNET_TOOL_PATH: '$(Agent.ToolsDirectory)/dotnet'
+
+- task: DotNetCoreCLI@2
+  displayName: '.NET Test for .NET 5'
+  inputs:
+    command: test
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} -f net5.0'
+  env:
+    DOTNET_TOOL_PATH: '$(Agent.ToolsDirectory)/dotnet'
+
+- task: DotNetCoreCLI@2
+  displayName: '.NET Test for .NET 6'
+  inputs:
+    command: test
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} -f net6.0'
+  env:
+    DOTNET_TOOL_PATH: '$(Agent.ToolsDirectory)/dotnet'
+
+- task: DotNetCoreCLI@2
+  displayName: '.NET Test for .NET 7'
+  inputs:
+    command: test
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} -f net7.0'
   env:
     DOTNET_TOOL_PATH: '$(Agent.ToolsDirectory)/dotnet'

--- a/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Build.Sql.Tests
             dotnet.BeginErrorReadLine();
 
             // Wait for dotnet build to finish with a timeout
-            TimeSpan timeout = TimeSpan.FromSeconds(30);
+            TimeSpan timeout = TimeSpan.FromSeconds(60);
             Stopwatch timer = new Stopwatch();
             timer.Start();
             dotnet.WaitForExit((int)timeout.TotalMilliseconds);

--- a/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Buld.Sql.Tests/DotnetTestBase.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using Microsoft.SqlServer.Dac;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
 
 namespace Microsoft.Build.Sql.Tests
 {
@@ -34,6 +35,23 @@ namespace Microsoft.Build.Sql.Tests
         public void TestSetup()
         {
             EnvironmentSetup();
+        }
+
+        [TearDown]
+        public void TestTearDown()
+        {
+            try
+            {
+                // Delete working directory unless test failed
+                if (TestContext.CurrentContext.Result.Outcome == ResultState.Success && Directory.Exists(this.WorkingDirectory))
+                {
+                    Directory.Delete(this.WorkingDirectory, true);
+                }
+            }
+            catch (Exception e)
+            {
+                Assert.Warn("TestTearDown failed with exception: {0}", e);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
- Have tests clean up working directory after each run
- Separate test runs by target framework in the pipeline. Since multi-targeting the tests, we quadrupled the number of tests, but they all run in a single task which increases issues due to parallelization. Also when a test fails, it's harder to determine which version of it failed.