### PR TITLE
Fix package reference to system dacpac

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -59,8 +59,8 @@
 
         <!-- File name of the dacpac inside the package -->
         <DacpacName>%(PackageReference.DacpacName)</DacpacName>
+        <DacpacName Condition="'%(_ResolvedDacpacPackageReference.DacpacName)' == '' And '%(_ResolvedDacpacPackageReference.IsSystemDacpac)' == 'true'">master</DacpacName>
         <DacpacName Condition="'%(_ResolvedDacpacPackageReference.DacpacName)' == ''">%(PackageReference.Identity)</DacpacName>
-        <DacpacName Condition="'%(_ResolvedDacpacPackageReference.IsSystemDacpac)' == 'true'">master</DacpacName>
 
         <!-- Full resolved path to the dacpac file -->
         <HintPath>%(PackageReference.HintPath)</HintPath>

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -55,7 +55,17 @@
         <!-- https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs#L763 -->
         <PackageId>@(PackageReference->'%(Identity)'->Replace('.', '_'))</PackageId>
         <PackagePath>$(Pkg%(_ResolvedDacpacPackageReference.PackageId))</PackagePath>
-        <HintPath>%(_ResolvedDacpacPackageReference.PackagePath)/tools/%(Identity).dacpac</HintPath>
+        <IsSystemDacpac>@(PackageReference->'%(Identity)'->ToLowerInvariant()->Contains('microsoft.sqlserver.dacpacs'))</IsSystemDacpac>
+
+        <!-- File name of the dacpac inside the package -->
+        <DacpacName>%(PackageReference.DacpacName)</DacpacName>
+        <DacpacName Condition="'%(_ResolvedDacpacPackageReference.DacpacName)' == ''">%(PackageReference.Identity)</DacpacName>
+        <DacpacName Condition="'%(_ResolvedDacpacPackageReference.IsSystemDacpac)' == 'true'">master</DacpacName>
+
+        <!-- Full resolved path to the dacpac file -->
+        <HintPath>%(PackageReference.HintPath)</HintPath>
+        <HintPath Condition="'%(_ResolvedDacpacPackageReference.HintPath)' == ''">%(_ResolvedDacpacPackageReference.PackagePath)/tools/%(_ResolvedDacpacPackageReference.DacpacName).dacpac</HintPath>
+
         <ServerSqlCmdVariable>%(PackageReference.ServerSqlCmdVariable)</ServerSqlCmdVariable>
         <DatabaseSqlCmdVariable>%(PackageReference.DatabaseSqlCmdVariable)</DatabaseSqlCmdVariable>
         <DatabaseVariableLiteralValue>%(PackageReference.DatabaseVariableLiteralValue)</DatabaseVariableLiteralValue>

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -75,5 +75,4 @@
       <ArtifactReference Include="@(_ResolvedDacpacPackageReference->'%(HintPath)')" Condition="Exists(%(HintPath))" />
     </ItemGroup>
   </Target>
-
 </Project>


### PR DESCRIPTION
Package references expect the dacpac name to be the same as package name, but is not the case for system dacpac packages. This change adds condition to check for `Microsoft.SqlServer.Dacpacs` package references and redirect to the master.dacpac within. Also adds `DacpacName` as an overridable atttribute to the PackageReference.