### PR TITLE
Update SDK  for separate master and msdb dacpacs

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -55,10 +55,15 @@
         <!-- https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs#L763 -->
         <PackageId>@(PackageReference->'%(Identity)'->Replace('.', '_'))</PackageId>
         <PackagePath>$(Pkg%(_ResolvedDacpacPackageReference.PackageId))</PackagePath>
-        <IsSystemDacpac>@(PackageReference->'%(Identity)'->ToLowerInvariant()->Contains('microsoft.sqlserver.dacpacs'))</IsSystemDacpac>
+        <IsSystemDacpac>@(PackageReference->'%(Identity)'->StartsWith('microsoft.sqlserver.dacpacs', StringComparison.OrdinalIgnoreCase))</IsSystemDacpac>
+        <IsMasterDacpac Condition="'%(_ResolvedDacpacPackageReference.IsSystemDacpac)' == 'true'">@(PackageReference->'%(Identity)'->EndsWith('master', StringComparison.OrdinalIgnoreCase))</IsMasterDacpac>
+        <IsMsdbDacpac Condition="'%(_ResolvedDacpacPackageReference.IsSystemDacpac)' == 'true'">@(PackageReference->'%(Identity)'->EndsWith('msdb', StringComparison.OrdinalIgnoreCase))</IsMsdbDacpac>
 
         <!-- File name of the dacpac inside the package -->
         <DacpacName>%(PackageReference.DacpacName)</DacpacName>
+        <DacpacName Condition="'%(_ResolvedDacpacPackageReference.DacpacName)' == '' And '%(_ResolvedDacpacPackageReference.IsMasterDacpac)' == 'true'">master</DacpacName>
+        <DacpacName Condition="'%(_ResolvedDacpacPackageReference.DacpacName)' == '' And '%(_ResolvedDacpacPackageReference.IsMsdbDacpac)' == 'true'">msdb</DacpacName>
+        <!-- Default to master for backwards compatibility with first versions of Microsoft.SqlServer.Dacpacs -->
         <DacpacName Condition="'%(_ResolvedDacpacPackageReference.DacpacName)' == '' And '%(_ResolvedDacpacPackageReference.IsSystemDacpac)' == 'true'">master</DacpacName>
         <DacpacName Condition="'%(_ResolvedDacpacPackageReference.DacpacName)' == ''">%(PackageReference.Identity)</DacpacName>
 


### PR DESCRIPTION
We will be shipping separate Microsoft.SqlServer.Dacpacs.Master and Microsoft.SqlServer.Dacpacs.Msdb Nuget packages, instead of the current Microsoft.SqlServer.Dacpacs which contains both. This change in the SDK will default to the corresponding dacpac name from the package referenced.