### PR TITLE
Default DatabaseVariableLiteralValue for master and msdb package references

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -74,6 +74,8 @@
         <ServerSqlCmdVariable>%(PackageReference.ServerSqlCmdVariable)</ServerSqlCmdVariable>
         <DatabaseSqlCmdVariable>%(PackageReference.DatabaseSqlCmdVariable)</DatabaseSqlCmdVariable>
         <DatabaseVariableLiteralValue>%(PackageReference.DatabaseVariableLiteralValue)</DatabaseVariableLiteralValue>
+        <DatabaseVariableLiteralValue Condition="'%(_ResolvedDacpacPackageReference.DatabaseVariableLiteralValue)' == '' And '%(_ResolvedDacpacPackageReference.IsMasterDacpac)' == 'true'">master</DatabaseVariableLiteralValue>
+        <DatabaseVariableLiteralValue Condition="'%(_ResolvedDacpacPackageReference.DatabaseVariableLiteralValue)' == '' And '%(_ResolvedDacpacPackageReference.IsMsdbDacpac)' == 'true'">msdb</DatabaseVariableLiteralValue>
         <SuppressMissingDependenciesErrors>%(PackageReference.SuppressMissingDependenciesErrors)</SuppressMissingDependenciesErrors>
       </_ResolvedDacpacPackageReference>
 

--- a/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Build.Sql.Tests
         {
             // Verify dacpac exists
             string dacpacPath = this.GetDacpacPath();
-            Assert.IsTrue(File.Exists(dacpacPath), "Dacpac not found: " + dacpacPath);
+            FileAssert.Exists(dacpacPath, "Dacpac not found: " + dacpacPath);
 
             // Verify pre/post-deploy scripts
             using (DacPackage package = DacPackage.Load(dacpacPath))


### PR DESCRIPTION
When there is a PackageReference to one of the system dacpac Nuget packages and `DatabaseVariableLiteralValue` is not set, it will be defaulted to either "master" or "msdb" respectively.

This is implied behavior already because build succeeds even without setting `DatabaseVariableLiteralValue`. However in the case when `GenerateCreateScript` is `true`, build fails with a null reference error like in #228.

Fixes #228 