### PR TITLE
Add pipeline to build SDK nightly and push to internal feed

### DIFF
--- a/builds/internal-nuget-build.yml
+++ b/builds/internal-nuget-build.yml
@@ -1,0 +1,91 @@
+trigger: none
+
+pr: none
+
+# Pipeline trigger - this pipeline will run whenever the 'DacFx-Official' pipeline finishes
+resources:
+  pipelines:
+  - pipeline: 'latest-nuget-build-test'
+    source: 'DacFx-Official'
+    trigger: true
+
+variables:
+  solution: '**/*.sln'
+  configuration: 'Release'
+  dacFxPackagePattern: 'Microsoft.SqlServer.DacFx*.nupkg'
+  dacFxPackagePath: '$(Pipeline.Workspace)/pkg'  # DacFx nupkg will be downloaded from nightly build and placed here
+  versionMajor: 0
+  versionMinor: 1
+  versionMajorMinor: '$(versionMajor).$(versionMinor)'  # This variable is only used for the counter
+  versionPatch: $[counter(variables['versionMajorMinor'], 0)] # This will reset when we bump either major or minor version
+  versionSuffix: 'beta'
+  nugetVersion: '$(versionMajor).$(versionMinor).$(versionPatch)-$(versionSuffix)'
+
+stages:
+- stage: Build
+  displayName: 'Nightly Push to Internal Feed'
+  jobs:
+  - job: BuildPush
+    displayName: 'Build and Push'
+    pool:
+      vmImage: 'ubuntu-latest'
+    workspace:
+      clean: all
+
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download Pipeline Artifact'
+      inputs:
+        buildType: 'specific'
+        project: '$(azureProjectId)'
+        definition: '$(azureSourcePipelineId)'
+        buildVersionToDownload: 'latest'
+        itemPattern: 'drop_build_main/release/$(dacFxPackagePattern)'
+        targetPath: '$(dacFxPackagePath)'
+
+    # Note: The download task above preserves the relative folder structure
+    - script: 'dotnet nuget add source "$(dacFxPackagePath)/drop_build_main/release"'
+      displayName: 'Nuget Add Source to Path Containing DacFx Package'
+
+    - task: PowerShell@2
+      displayName: 'Extract Version from DacFx nupkg file'
+      inputs:
+        failOnStderr: true
+        targetType: 'inline'
+        script: |
+          # Locate the nupkg file from the package path
+          $files =  Get-ChildItem "$(dacFxPackagePath)" -Recurse -Include "$(dacFxPackagePattern)"
+          Write-Host "DacFx package found in $files"
+          if ($files.length -eq 0) {
+            Write-Error "Failed to find Nuget package with pattern $(dacFxPackagePattern) in $(dacFxPackagePath)"
+          }
+
+          # Parse the nupkg file name for the version number
+          $filename = Split-Path $files[0] -leaf
+          $version = $filename.Replace("Microsoft.SqlServer.DacFx.", "").Replace(".nupkg", "")
+          Write-Host "DacFx package version: $version"
+          Write-Host "##vso[task.setvariable variable=dacFxPackageVersion]$version"
+        
+    - template: 'template-steps-build-test.yml'
+      parameters:
+        solution: '$(solution)'
+        configuration: '$(configuration)'
+        nugetVersion: '$(nugetVersion)'
+        runCodeSign: 'true'
+        dacFxPackageVersionArgument: '-p:DacFxPackageVersion="$(dacFxPackageVersion)"'
+
+    - template: 'template-steps-publish.yml'
+      parameters:
+        configuration: '$(configuration)'
+    
+    - task: NuGetAuthenticate@0
+      displayName: 'NuGet Authenticate'
+
+    - task: NuGetCommand@2
+      displayName: 'Push NuGet Package'
+      inputs:
+        command: push
+        packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
+        publishVstsFeed: 'SQLDS_SSMS'
+        publishPackageMetadata: false
+        nuGetFeedType: 'internal'

--- a/builds/template-steps-publish.yml
+++ b/builds/template-steps-publish.yml
@@ -48,7 +48,7 @@ steps:
   displayName: 'Push NuGet Package'
   inputs:
     command: push
-    packagesToPush: '**/*.nupkg'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
     publishVstsFeed: 'SQLDS_SSMS'
     publishPackageMetadata: false
     nuGetFeedType: 'internal'

--- a/builds/template-steps-publish.yml
+++ b/builds/template-steps-publish.yml
@@ -40,15 +40,3 @@ steps:
   inputs:
     targetPath: '$(Build.ArtifactStagingDirectory)'
     artifactName: 'drop'
-
-- task: NuGetAuthenticate@0
-  displayName: 'NuGet Authenticate'
-
-- task: NuGetCommand@2
-  displayName: 'Push NuGet Package'
-  inputs:
-    command: push
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
-    publishVstsFeed: 'SQLDS_SSMS'
-    publishPackageMetadata: false
-    nuGetFeedType: 'internal'

--- a/builds/template-steps-publish.yml
+++ b/builds/template-steps-publish.yml
@@ -48,7 +48,7 @@ steps:
   displayName: 'Push NuGet Package'
   inputs:
     command: push
-    packagesToPush: '*.nupkg'
+    packagesToPush: '**/*.nupkg'
     publishVstsFeed: 'SQLDS_SSMS'
     publishPackageMetadata: false
     nuGetFeedType: 'internal'

--- a/builds/template-steps-publish.yml
+++ b/builds/template-steps-publish.yml
@@ -40,3 +40,15 @@ steps:
   inputs:
     targetPath: '$(Build.ArtifactStagingDirectory)'
     artifactName: 'drop'
+
+- task: NuGetAuthenticate@0
+  displayName: 'NuGet Authenticate'
+
+- task: NuGetCommand@2
+  displayName: 'Push NuGet Package'
+  inputs:
+    command: push
+    packagesToPush: '*.nupkg'
+    publishVstsFeed: 'SQLDS_SSMS'
+    publishPackageMetadata: false
+    nuGetFeedType: 'internal'


### PR DESCRIPTION
* New pipeline: https://msdata.visualstudio.com/SQLToolsAndLibraries/_build?definitionId=22441&_a=summary
* Runs after each DacFx-Official build
* Version auto-increments, with suffix "beta"