### PR TITLE
Fix templates Nuget package

### DIFF
--- a/src/Microsoft.Build.Sql.Templates/Microsoft.Build.Sql.Templates.csproj
+++ b/src/Microsoft.Build.Sql.Templates/Microsoft.Build.Sql.Templates.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(EnlistmentRoot)/LICENSE.txt" PackagePath="/" Pack="true" />
+    <Content Include="$(TemplateIntermediateOutputPath)\**" PackagePath="content/" Pack="true" />
   </ItemGroup>
 
   <Target Name="CleanIntermediateFolder" AfterTargets="Clean">


### PR DESCRIPTION
In #355 I removed a duplicate `<Content>` line in the templates csproj which was causing a build warning. It didn't cause any issues locally or in tests, but the release pipeline is now generating an empty templates nupkg. I believe this is because the pipeline runs build and pack separately, so the `<Content>` from the `CopyTemplateFiles` target isn't included.

I'll restore the other Content for now and look for other ways to resolve the build warning later.