### PR TITLE
Adding VS targets path and Excluding BuildExtensionConfiguration and DeployExtensionConfiguration from Build

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -73,6 +73,8 @@
     <Build Remove="@(PreDeploy)" />
     <Build Remove="@(PostDeploy)" />
     <Build Remove="@(None)" />
+    <Build Remove="@(BuildExtensionConfiguration)" />
+    <Build Remove="@(DeployExtensionConfiguration)" />
   </ItemGroup>
 
   <!-- Target to resolve package references into database references to the underlying DACPACs inside the packages -->

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -53,6 +53,9 @@
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets" />
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets" />
 
+  <Import Condition="'$(NetCoreBuild)' != 'true' AND Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets')"
+          Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets" />
+
   <!-- Add dacpac file BuiltProjectOutputGroupOutput, so that it will get included in the NuGet package by the Pack target -->
   <Target Name="AddDacpacToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup">
     <ItemGroup>

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -74,7 +74,7 @@
     <Build Remove="@(PostDeploy)" />
     <Build Remove="@(None)" />
     <Build Remove="@(BuildExtensionConfiguration)" />
-    <Build Remove="@(DeployExtensionConfiguration)" />
+    <Build Remove="@(DeploymentExtensionConfiguration)" />
   </ItemGroup>
 
   <!-- Target to resolve package references into database references to the underlying DACPACs inside the packages -->

--- a/test/Microsoft.Build.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/BuildTests.cs
@@ -57,6 +57,64 @@ namespace Microsoft.Build.Sql.Tests
         }
 
         [Test]
+        [Description("Verifies build with deployment extension configuration script.")]
+        public void SuccessfulBuildWithDeploymentExtensionConfigurationScript()
+        {
+            this.AddDeploymentExtensionConfigurationScripts("Table2.sql");
+
+            string stdOutput, stdError;
+            int exitCode = this.RunDotnetCommandOnProject("build", out stdOutput, out stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Verify the Table2 is not part of the model
+            using (TSqlModel model = new TSqlModel(this.GetDacpacPath()))
+            {
+                var tables = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Table);
+                Assert.IsTrue(tables.Any(), "Expected at least 1 table in the model.");
+                foreach (var table in tables)
+                {
+                    if (table.Name.ToString().IndexOf("Table2", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        Assert.Fail("Table2 should have been excluded from the model.");
+                    }
+                }
+            }
+        }
+
+        [Test]
+        [Description("Verifies build with build extension configuration script.")]
+        public void SuccessfulBuildWithBuildExtensionConfigurationScript()
+        {
+            this.AddBuildExtensionConfigurationScripts("Table2.sql");
+
+            string stdOutput, stdError;
+            int exitCode = this.RunDotnetCommandOnProject("build", out stdOutput, out stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Verify the Table2 is not part of the model
+            using (TSqlModel model = new TSqlModel(this.GetDacpacPath()))
+            {
+                var tables = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Table);
+                Assert.IsTrue(tables.Any(), "Expected at least 1 table in the model.");
+                foreach (var table in tables)
+                {
+                    if (table.Name.ToString().IndexOf("Table2", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        Assert.Fail("Table2 should have been excluded from the model.");
+                    }
+                }
+            }
+        }
+
+        [Test]
         [Description("Verifies build with excluding file from project.")]
         public void BuildWithExclude()
         {

--- a/test/Microsoft.Build.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/BuildTests.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Build.Sql.Tests
         [Description("Verifies build with deployment extension configuration script.")]
         public void SuccessfulBuildWithDeploymentExtensionConfigurationScript()
         {
+            this.RemoveBuildFiles("Table2.sql"); 
             this.AddDeploymentExtensionConfigurationScripts("Table2.sql");
 
             string stdOutput, stdError;
@@ -89,6 +90,7 @@ namespace Microsoft.Build.Sql.Tests
         [Description("Verifies build with build extension configuration script.")]
         public void SuccessfulBuildWithBuildExtensionConfigurationScript()
         {
+            this.RemoveBuildFiles("Table2.sql"); 
             this.AddBuildExtensionConfigurationScripts("Table2.sql");
 
             string stdOutput, stdError;

--- a/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
@@ -251,6 +251,22 @@ namespace Microsoft.Build.Sql.Tests
         }
 
         /// <summary>
+        /// Add deploymentextensionconfiguration scripts to the project. <paramref name="files"/> paths are relative.
+        /// </summary>
+        protected void AddDeploymentExtensionConfigurationScripts(params string[] files)
+        {
+            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "DeploymentExtensionConfiguration", files);
+        }
+
+        /// <summary>
+        /// Add buildextensionconfiguration scripts to the project. <paramref name="files"/> paths are relative.
+        /// </summary>
+        protected void AddBuildExtensionConfigurationScripts(params string[] files)
+        {
+            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "BuildExtensionConfiguration", files);
+        }
+
+        /// <summary>
         /// Add scripts to the project that are not part of build. <paramref name="files"/> paths are relative.
         /// </summary>
         protected void AddNoneScripts(params string[] files)

--- a/test/Microsoft.Build.Sql.Tests/TestData/SuccessfulBuildWithBuildExtensionConfigurationScript/Table1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/SuccessfulBuildWithBuildExtensionConfigurationScript/Table1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[Table1]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)

--- a/test/Microsoft.Build.Sql.Tests/TestData/SuccessfulBuildWithBuildExtensionConfigurationScript/Table2.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/SuccessfulBuildWithBuildExtensionConfigurationScript/Table2.sql
@@ -1,0 +1,6 @@
+-- This file to be excluded from project by the test
+CREATE TABLE [dbo].[Table2]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)

--- a/test/Microsoft.Build.Sql.Tests/TestData/SuccessfulBuildWithDeploymentExtensionConfigurationScript/Table1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/SuccessfulBuildWithDeploymentExtensionConfigurationScript/Table1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[Table1]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)

--- a/test/Microsoft.Build.Sql.Tests/TestData/SuccessfulBuildWithDeploymentExtensionConfigurationScript/Table2.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/SuccessfulBuildWithDeploymentExtensionConfigurationScript/Table2.sql
@@ -1,0 +1,6 @@
+-- This file to be excluded from project by the test
+CREATE TABLE [dbo].[Table2]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)


### PR DESCRIPTION
- Importing SSDTProjectSystem Targets Path to support SDK Style in Visual Studio.
- Excluding files with BuildExtensionConfiguration and DeployExtensionConfiguration BuildAction from Build