### PR TITLE
Add support for dotnet publish

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -12,6 +12,7 @@
     <NetCoreBuild Condition="'$(NetCoreBuild)' == '' And '$(MSBuildRuntimeType)' == 'Full'">false</NetCoreBuild>
     <NETCoreTargetsPath Condition="$(NETCoreTargetsPath) == ''">$(MSBuildThisFileDirectory)..\tools\netstandard2.1</NETCoreTargetsPath>
     <TargetFramework Condition="'$(TargetFramework)' == '' AND '$(NetCoreBuild)' == 'true'">netstandard2.1</TargetFramework>
+    <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
   </PropertyGroup>
 
   <!-- building in Visual Studio requires some sort of TargetFrameworkVersion. So we condition to NetCoreBuild as false to avoid failures -->

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -28,6 +28,8 @@
     <DebugSymbols Condition=" '$(DebugSymbols)' == '' ">true</DebugSymbols>
   </PropertyGroup>
 
+  <Import Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/Sdk/Sdk.BeforeCommon.targets" />
+
   <!-- Pack target properties -->
   <PropertyGroup>
     <PackageType>$(PackageType);DACPAC</PackageType>
@@ -60,6 +62,12 @@
   <Target Name="AddDacpacToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup">
     <ItemGroup>
       <BuiltProjectOutputGroupOutput Include="$(SqlTargetPath)" TargetPath="$(SqlTargetFile)" FinalOutputPath="$(SqlTargetPath)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddDacpacToPublishList" BeforeTargets="ComputeResolvedFilesToPublishList">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(SqlTargetPath)" RelativePath="$(SqlTargetFile)" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -58,7 +58,7 @@
           Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets" />
           
   <!-- Override some .NET targets that aren't necessary for SqlBuild but may cause issues if not overridden -->
-  <Target Name="_CheckForUnsupportedTargetFrameworkAndFeatureCombination" />
+  <Target Name="_CheckForUnsupportedTargetFrameworkAndFeatureCombination" Condition="true" />
 
   <!-- Add dacpac file BuiltProjectOutputGroupOutput, so that it will get included in the NuGet package by the Pack target -->
   <Target Name="AddDacpacToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup">

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -28,8 +28,6 @@
     <DebugSymbols Condition=" '$(DebugSymbols)' == '' ">true</DebugSymbols>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/Sdk/Sdk.BeforeCommon.targets" />
-
   <!-- Pack target properties -->
   <PropertyGroup>
     <PackageType>$(PackageType);DACPAC</PackageType>
@@ -51,12 +49,16 @@
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/Sdk/Sdk.BeforeCommon.targets" />
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/targets/Microsoft.NET.DefaultAssemblyInfo.targets" />
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets" />
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets" />
 
   <Import Condition="'$(NetCoreBuild)' != 'true' AND Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets')"
           Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets" />
+          
+  <!-- Override some .NET targets that aren't necessary for SqlBuild but may cause issues if not overridden -->
+  <Target Name="_CheckForUnsupportedTargetFrameworkAndFeatureCombination" />
 
   <!-- Add dacpac file BuiltProjectOutputGroupOutput, so that it will get included in the NuGet package by the Pack target -->
   <Target Name="AddDacpacToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup">

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -38,6 +38,12 @@
     <NoWarn>$(NoWarn),NU5128</NoWarn>
   </PropertyGroup>
 
+  <!-- Publish target properties -->
+  <PropertyGroup>
+    <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
+    <PublishDir Condition="'$(PublishDir)' == ''">$(OutputPath)$(PublishDirName)\</PublishDir>
+  </PropertyGroup>
+
   <Target Name="CreateManifestResourceNames" />
   <!-- CoreCompile is a target inside target Build on Microsoft.Common.targets that is not implemented there but allows us to personalize our compile/build flow, while
     executing all the other targets inside Build regularly. We implement it before importing Common.targets because it's not implemented there, so it will not be
@@ -48,17 +54,15 @@
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildThisFileDirectory)../tools/netstandard2.1/Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
-  
-  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/Sdk/Sdk.BeforeCommon.targets" />
+
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/targets/Microsoft.NET.DefaultAssemblyInfo.targets" />
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets" />
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets" />
 
   <Import Condition="'$(NetCoreBuild)' != 'true' AND Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets')"
           Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets" />
-          
-  <!-- Override some .NET targets that aren't necessary for SqlBuild but may cause issues if not overridden -->
-  <Target Name="_CheckForUnsupportedTargetFrameworkAndFeatureCombination" Condition="true" />
+
+  <UsingTask TaskName="AllowEmptyTelemetry" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <!-- Add dacpac file BuiltProjectOutputGroupOutput, so that it will get included in the NuGet package by the Pack target -->
   <Target Name="AddDacpacToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup">

--- a/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
@@ -37,10 +37,19 @@ namespace Microsoft.Build.Sql.Tests
             get { return Path.Combine(this.CommonTestDataDirectory, TestUtils.EscapeTestName(TestContext.CurrentContext.Test.Name)); }
         }
 
+        private string LocalNugetSource
+        {
+            get { return Path.Combine(this.WorkingDirectory, "pkg"); }
+        }
+
         [SetUp]
         public void TestSetup()
         {
             EnvironmentSetup();
+
+            // Add pkg folder as a nuget source
+            RunGenericDotnetCommand($"nuget add source \"{LocalNugetSource}\" --name TestSource_{TestContext.CurrentContext.Test.Name}", out _, out string stdError);
+            Assert.AreEqual("", stdError, "Failed to add local nuget source: " + stdError);
         }
 
         [TearDown]
@@ -86,8 +95,7 @@ namespace Microsoft.Build.Sql.Tests
             }
 
             // Copy SDK nuget package to Workingdirectory/pkg/
-            string localNugetSource = Path.Combine(this.WorkingDirectory, "pkg");
-            TestUtils.CopyDirectoryRecursive("../../../pkg", localNugetSource);
+            TestUtils.CopyDirectoryRecursive("../../../pkg", LocalNugetSource);
 
             // Copy common project files from Template to WorkingDirectory
             TestUtils.CopyDirectoryRecursive("../../../Template", this.WorkingDirectory);
@@ -97,10 +105,6 @@ namespace Microsoft.Build.Sql.Tests
             {
                 TestUtils.CopyDirectoryRecursive(this.CurrentTestDataDirectory, this.WorkingDirectory);
             }
-
-            // Add pkg folder as a nuget source
-            RunGenericDotnetCommand($"nuget add source \"{localNugetSource}\" --name TestSource_{TestContext.CurrentContext.Test.Name}", out _, out string stdError);
-            Assert.AreEqual("", stdError, "Failed to add local nuget source: " + stdError);
         }
 
         /// <summary>

--- a/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using Microsoft.Build.Construction;
 using Microsoft.SqlServer.Dac;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
@@ -292,6 +293,36 @@ namespace Microsoft.Build.Sql.Tests
         protected void AddProjectReference(params string[] projects)
         {
             ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "ProjectReference", projects);
+        }
+
+        /// <summary>
+        /// Add a package reference to a Nuget package.
+        /// </summary>
+        protected void AddPackageReference(string packageName, string version, string serverSqlcmdVariable = "", string databaseSqlcmdVariable = "", string databaseVariableLiteralValue = "", bool? suppressMissingDependenciesErrors = null)
+        {
+            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "PackageReference", new string[] { packageName }, (ProjectItemElement item) => {
+                item.AddMetadata("Version", version);
+
+                if (!string.IsNullOrEmpty(serverSqlcmdVariable))
+                {
+                    item.AddMetadata("ServerSqlCmdVariable", serverSqlcmdVariable);
+                }
+
+                if (!string.IsNullOrEmpty(databaseSqlcmdVariable))
+                {
+                    item.AddMetadata("DatabaseSqlCmdVariable", databaseSqlcmdVariable);
+                }
+
+                if (!string.IsNullOrEmpty(databaseVariableLiteralValue))
+                {
+                    item.AddMetadata("DatabaseVariableLiteralValue", databaseVariableLiteralValue);
+                }
+
+                if (suppressMissingDependenciesErrors.HasValue)
+                {
+                    item.AddMetadata("SuppressMissingDependenciesErrors", suppressMissingDependenciesErrors.ToString());
+                }
+            });
         }
 
         /// <summary>

--- a/test/Microsoft.Build.Sql.Tests/PackageReferenceTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/PackageReferenceTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Build.Construction;
 using NUnit.Framework;
 
 namespace Microsoft.Build.Sql.Tests
@@ -109,34 +108,6 @@ namespace Microsoft.Build.Sql.Tests
             Assert.AreEqual(string.Empty, stdError);
             this.VerifyDacPackage();
             FileAssert.Exists(Path.Combine(this.GetOutputDirectory(), $"{DatabaseProjectName}_Create.sql"));
-        }
-
-        private void AddPackageReference(string packageName, string version, string serverSqlcmdVariable = "", string databaseSqlcmdVariable = "", string databaseVariableLiteralValue = "", bool? suppressMissingDependenciesErrors = null)
-        {
-            // Add a package reference to ReferenceProj version 5.5.5
-            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "PackageReference", new string[] { packageName }, (ProjectItemElement item) => {
-                item.AddMetadata("Version", version);
-
-                if (!string.IsNullOrEmpty(serverSqlcmdVariable))
-                {
-                    item.AddMetadata("ServerSqlCmdVariable", serverSqlcmdVariable);
-                }
-
-                if (!string.IsNullOrEmpty(databaseSqlcmdVariable))
-                {
-                    item.AddMetadata("DatabaseSqlCmdVariable", databaseSqlcmdVariable);
-                }
-
-                if (!string.IsNullOrEmpty(databaseVariableLiteralValue))
-                {
-                    item.AddMetadata("DatabaseVariableLiteralValue", databaseVariableLiteralValue);
-                }
-
-                if (suppressMissingDependenciesErrors.HasValue)
-                {
-                    item.AddMetadata("SuppressMissingDependenciesErrors", suppressMissingDependenciesErrors.ToString());
-                }
-            });
         }
     }
 }

--- a/test/Microsoft.Build.Sql.Tests/PublishTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/PublishTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using Microsoft.Build.Construction;
+using NUnit.Framework;
+
+namespace Microsoft.Build.Sql.Tests
+{
+    [TestFixture]
+    public class PublishTests : DotnetTestBase
+    {
+        [Test]
+        public void VerifySimplePublish()
+        {
+            int exitCode = this.RunDotnetCommandOnProject("publish", out _, out string stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Publish failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+            this.VerifyPublishFolder();
+        }
+
+        [Test]
+        public void VerifyPublishWithNoBuild()
+        {
+            // Run build first
+            int exitCode = this.RunDotnetCommandOnProject("publish", out _, out string stdError);
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Run publish with --no-build
+            exitCode = this.RunDotnetCommandOnProject("publish --no-build", out _, out stdError);
+            Assert.AreEqual(0, exitCode, "publish failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyPublishFolder();
+        }
+
+        [Test]
+        public void VerifyPublishkWithIncludedFiles()
+        {
+            // Add a content file that is copied to output
+            string includedContent = Path.Combine(this.WorkingDirectory, "include_content.txt");
+            File.WriteAllText(includedContent, "test");
+            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "Content", new[] { includedContent }, (ProjectItemElement item) =>
+            {
+                item.AddMetadata("CopyToOutputDirectory", "PreserveNewest");
+            });
+
+            // Run dotnet publish
+            int exitCode = this.RunDotnetCommandOnProject("publish", out _, out string stdError);
+
+            // Verify
+            Assert.AreEqual(0, exitCode, "Publish failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyPublishFolder("include_content.txt");
+        }
+
+        [Test]
+        public void VerifyPublishWithProjectReference()
+        {
+            // Add a project reference to ReferenceProj, which should be copied to the publish directory
+            string tempFolder = TestUtils.CreateTempDirectory();
+            TestUtils.CopyDirectoryRecursive(Path.Combine(this.CommonTestDataDirectory, "ReferenceProj"), tempFolder);
+
+            this.AddProjectReference(Path.Combine(tempFolder, "ReferenceProj.sqlproj"));
+
+            int exitCode = this.RunDotnetCommandOnProject("publish", out _, out string stdError);
+
+            Assert.AreEqual(0, exitCode, "Publish failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+            this.VerifyPublishFolder("ReferenceProj.dacpac");
+        }
+
+        [Test]
+        public void VerifyPublishWithPackageReference()
+        {
+            // Add a package reference to master.dacpac, which should be copied to the publish directory
+            this.AddPackageReference(packageName: "Microsoft.SqlServer.Dacpacs.Azure.Master", version: "160.*");
+
+            int exitCode = this.RunDotnetCommandOnProject("publish", out _, out string stdError);
+
+            Assert.AreEqual(0, exitCode, "Publish failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+            this.VerifyPublishFolder("master.dacpac");
+        }
+
+        /// <summary>
+        /// Verify dacpac is in the publish directory, along with any additional expected files.
+        /// </summary>
+        private void VerifyPublishFolder(params string[] additionalFiles)
+        {
+            string publishFolder = Path.Combine(this.GetOutputDirectory(), "publish");
+            FileAssert.Exists(Path.Combine(publishFolder, $"{DatabaseProjectName}.dacpac"));
+            foreach (string file in additionalFiles) {
+                FileAssert.Exists(Path.Combine(publishFolder, file));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Running `dotnet publish` will place the dacpac and all dependencies into the `publish` folder. Note this does not publish dacpac to databasae, please use sqlpackage for that.

Closes #447 