### PR TITLE
Add target to remove included files via :r from build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <RepositoryUrl>https://github.com/microsoft/DacFx</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 
+    <!-- TODO: vBump DacFx -->
     <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">162.4.92</DacFxPackageVersion>
     <ScriptDomPackageVersion Condition="'$(ScriptDomPackageVersion)' == ''">161.9142.1</ScriptDomPackageVersion>
     <SqlClientPackageVersion Condition="'$(SqlClientPackageVersion)' == ''">5.1.6</SqlClientPackageVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/microsoft/DacFx</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 
-    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">162.4.87-preview</DacFxPackageVersion>
+    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">162.4.92</DacFxPackageVersion>
     <ScriptDomPackageVersion Condition="'$(ScriptDomPackageVersion)' == ''">161.9142.1</ScriptDomPackageVersion>
     <SqlClientPackageVersion Condition="'$(SqlClientPackageVersion)' == ''">5.1.6</SqlClientPackageVersion>
   </PropertyGroup>

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -63,6 +63,13 @@
     </ItemGroup>
   </Target>
 
+  <!-- Remove files included via :r in pre/post-deployment scripts from build. Fix for https://github.com/microsoft/DacFx/issues/103 -->
+  <Target Name="RemoveSqlCmdIncludeFilesFromBuild" BeforeTargets="SqlBuild" DependsOnTargets="_SetupSqlBuildInputs">
+    <ItemGroup>
+      <Build Remove="@(__SqlScriptDependentFiles)" MatchOnMetadata="Identity" MatchOnMetadataOptions="PathLike" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <!-- This is necessary for building on non-Windows platforms. -->
     <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" IsImplicitlyDefined="true" />

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -70,7 +70,7 @@
       <BuiltProjectOutputGroupOutput Include="$(SqlTargetPath)" TargetPath="$(SqlTargetFile)" FinalOutputPath="$(SqlTargetPath)" />
     </ItemGroup>
   </Target>
-  
+
   <Target Name="AddDacpacToPublishList" BeforeTargets="ComputeResolvedFilesToPublishList">
     <ItemGroup>
       <ResolvedFileToPublish Include="$(SqlTargetPath)" RelativePath="$(SqlTargetFile)" CopyToPublishDirectory="PreserveNewest" />

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -70,16 +70,17 @@
       <BuiltProjectOutputGroupOutput Include="$(SqlTargetPath)" TargetPath="$(SqlTargetFile)" FinalOutputPath="$(SqlTargetPath)" />
     </ItemGroup>
   </Target>
+  
+  <Target Name="AddDacpacToPublishList" BeforeTargets="ComputeResolvedFilesToPublishList">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(SqlTargetPath)" RelativePath="$(SqlTargetFile)" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
 
   <!-- Remove files included via :r in pre/post-deployment scripts from build. Fix for https://github.com/microsoft/DacFx/issues/103 -->
   <Target Name="RemoveSqlCmdIncludeFilesFromBuild" BeforeTargets="SqlBuild" DependsOnTargets="_SetupSqlBuildInputs">
     <ItemGroup>
       <Build Remove="@(__SqlScriptDependentFiles)" MatchOnMetadata="Identity" MatchOnMetadataOptions="PathLike" />
-  </Target>
-  
-  <Target Name="AddDacpacToPublishList" BeforeTargets="ComputeResolvedFilesToPublishList">
-    <ItemGroup>
-      <ResolvedFileToPublish Include="$(SqlTargetPath)" RelativePath="$(SqlTargetFile)" CopyToPublishDirectory="PreserveNewest" />
     </ItemGroup>
   </Target>
 

--- a/test/Microsoft.Build.Sql.Tests/TestData/VerifyBuildWithIncludeFiles/Script.PostDeployment1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/VerifyBuildWithIncludeFiles/Script.PostDeployment1.sql
@@ -1,0 +1,1 @@
+:r Table2.sql

--- a/test/Microsoft.Build.Sql.Tests/TestData/VerifyBuildWithIncludeFiles/Table1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/VerifyBuildWithIncludeFiles/Table1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[Table1]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)

--- a/test/Microsoft.Build.Sql.Tests/TestData/VerifyBuildWithIncludeFiles/Table2.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/VerifyBuildWithIncludeFiles/Table2.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[Table2]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)


### PR DESCRIPTION
Fixes #103 

New version of SqlTasks.targets will put all the included files via `:r` in pre/post-deployment scripts in a new `@(__SqlScriptDependentFiles)` item. We can then use this item in the sdk.targets to exclude them from build.