### PR TITLE
Fix tests on release configuration

### DIFF
--- a/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
@@ -15,12 +15,6 @@ namespace Microsoft.Build.Sql.Tests
     {
         protected string DatabaseProjectName = "project";
 
-#if DEBUG
-        protected const bool IsDebug = true;
-#else
-        protected const bool IsDebug = false;
-#endif
-
         protected string WorkingDirectory
         {
             get { return Path.Combine(TestContext.CurrentContext.WorkDirectory, TestUtils.EscapeTestName(TestContext.CurrentContext.Test.Name)); }
@@ -315,8 +309,7 @@ namespace Microsoft.Build.Sql.Tests
         /// </summary>
         protected string GetOutputDirectory()
         {
-            string configuration = IsDebug ? "Debug" : "Release";
-            return Path.Combine(this.WorkingDirectory, "bin", configuration);
+            return Path.Combine(this.WorkingDirectory, "bin", "Debug");
         }
 
         /// <summary>


### PR DESCRIPTION
When running project build tests against release configuration, it used to also default to Release configuration for the tests, but that no longer seems to be the case after switching to OneBranch. 