### PR TITLE
Fix issue 520

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -6,7 +6,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="$(MSBuildSdksPath)\Microsoft.NET.Sdk\targets\Microsoft.NET.SupportedTargetFrameworks.props" Condition="Exists('$(MSBuildSdksPath)\Microsoft.NET.Sdk\targets\Microsoft.NET.SupportedTargetFrameworks.props')" />
 
   <PropertyGroup>
     <NetCoreBuild Condition="'$(NetCoreBuild)' == '' And '$(MSBuildRuntimeType)' == 'Core'">true</NetCoreBuild>
@@ -14,8 +13,9 @@
     <NETCoreTargetsPath Condition="$(NETCoreTargetsPath) == ''">$(MSBuildThisFileDirectory)..\tools\netstandard2.1</NETCoreTargetsPath>
     <TargetFramework Condition="'$(TargetFramework)' == '' AND '$(NetCoreBuild)' == 'true'">netstandard2.1</TargetFramework>
     <!-- Allow packages of all target frameworks to be referenced by the sqlproj -->
-    <PackageTargetFallback Condition="'$(PackageTargetFallback)' == ''">@(SupportedTargetFramework->'%(Alias)')</PackageTargetFallback>
+    <AssetTargetFallback Condition="'$(AssetTargetFallback)' == ''">@(SupportedTargetFramework->'%(Alias)')</AssetTargetFallback>
     <PublishDirName Condition="'$(PublishDirName)' == ''">publish</PublishDirName>
+    <ImplicitlyExpandNETStandardFacades Condition="'$(ImplicitlyExpandNETStandardFacades)' == ''">false</ImplicitlyExpandNETStandardFacades>
   </PropertyGroup>
 
   <!-- building in Visual Studio requires some sort of TargetFrameworkVersion. So we condition to NetCoreBuild as false to avoid failures -->

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -34,8 +34,8 @@
     <IsTool Condition="'$(IsTool)' == ''">true</IsTool>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.dacpac</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
-    <!-- Suppress NU5128 since SQL NuGet Packages have no target framework dependencies -->
-    <NoWarn>$(NoWarn),NU5128</NoWarn>
+    <!-- Suppress NuGet warnings since SQL NuGet Packages have no target framework dependencies -->
+    <NoWarn>$(NoWarn),NU1701,NU5128</NoWarn>
   </PropertyGroup>
 
   <!-- Publish target properties -->
@@ -51,6 +51,8 @@
     -->
   <Target Name="CoreCompile" />
 
+  <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildSdksPath)/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.BeforeCommon.targets" />
+
   <Import Condition="'$(NetCoreBuild)' == 'true'" Project="$(MSBuildThisFileDirectory)../tools/netstandard2.1/Microsoft.Data.Tools.Schema.SqlTasks.targets"/>
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' != ''" Project="$(SQLDBExtensionsRefPath)\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
   <Import Condition="'$(NetCoreBuild)' != 'true' AND '$(SQLDBExtensionsRefPath)' == ''" Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets" />
@@ -61,6 +63,9 @@
 
   <Import Condition="'$(NetCoreBuild)' != 'true' AND Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets')"
           Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets" />
+
+  <!-- Override target to skip invalid .NET Framework check -->
+  <Target Name="_CheckForUnsupportedTargetFrameworkAndFeatureCombination" />
 
   <UsingTask Condition="'$(NetCoreBuild)' == 'true'" TaskName="AllowEmptyTelemetry" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
@@ -86,7 +91,7 @@
 
   <ItemGroup>
     <!-- This is necessary for building on non-Windows platforms. -->
-    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" IsImplicitlyDefined="true" />
+    <PackageReference Condition="'$(NetCoreBuild)' == 'true'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" IsImplicitlyDefined="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Build.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/BuildTests.cs
@@ -389,5 +389,25 @@ namespace Microsoft.Build.Sql.Tests
                 }
             }
         }
+
+        [Test]
+        // https://github.com/microsoft/DacFx/issues/520
+        public void BuildWithExternalReference()
+        {
+            // Build a ReferenceProj with a table
+            string tempFolder = TestUtils.CreateTempDirectory();
+            TestUtils.CopyDirectoryRecursive(Path.Combine(this.CommonTestDataDirectory, "ReferenceProj"), tempFolder);
+
+            // Add project reference and build with a synonym created from the external table, and a view on the synonym
+            this.AddProjectReference(Path.Combine(tempFolder, "ReferenceProj.sqlproj"), databaseSqlcmdVariable: "ReferenceDb");
+            int exitCode = this.RunDotnetCommandOnProject("build", out string stdOutput, out string stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            Directory.Delete(tempFolder, true);
+        }
     }
 }

--- a/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
@@ -286,11 +286,16 @@ namespace Microsoft.Build.Sql.Tests
         }
 
         /// <summary>
-        /// Add references to another project(s). <paramref name="projects"/> paths are relative.
+        /// Add reference to another project. <paramref name="project"/> path is relative.
         /// </summary>
-        protected void AddProjectReference(params string[] projects)
+        protected void AddProjectReference(string project, string databaseSqlcmdVariable = "")
         {
-            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "ProjectReference", projects);
+            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "ProjectReference", new string[] { project }, (ProjectItemElement item) => {
+                if (!string.IsNullOrEmpty(databaseSqlcmdVariable))
+                {
+                    item.AddMetadata("DatabaseSqlCmdVariable", databaseSqlcmdVariable);
+                }
+            });
         }
 
         /// <summary>

--- a/test/Microsoft.Build.Sql.Tests/TestData/BuildWithExternalReference/Synonym1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/BuildWithExternalReference/Synonym1.sql
@@ -1,0 +1,1 @@
+CREATE SYNONYM Synonym1 FOR [$(ReferenceDb)].[dbo].[Table1]

--- a/test/Microsoft.Build.Sql.Tests/TestData/BuildWithExternalReference/View1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/BuildWithExternalReference/View1.sql
@@ -1,0 +1,2 @@
+CREATE VIEW [dbo].[View1]
+	AS SELECT * FROM Synonym1


### PR DESCRIPTION
Fixes #520 

msbuild is somehow resolving direct project references as transitive, which overwrites the correct `ProjectReference` with SQLCMD variables. Importing the Microsoft.NET.Sdk.BeforeCommon.targets fixes it, but need additional changes for targeting .NET Framework to work.

![image](https://github.com/user-attachments/assets/81a1c87f-1895-4d2e-a84c-2f8157416b57)
