### PR TITLE
Use DevelopmentDependency

### DIFF
--- a/src/Microsoft.Build.Sql.Templates/sqlcodeanalysis/SqlCodeAnalysis1.csproj
+++ b/src/Microsoft.Build.Sql.Templates/sqlcodeanalysis/SqlCodeAnalysis1.csproj
@@ -4,6 +4,7 @@
     <PackageId>Sample.SqlCodeAnalysis1</PackageId>
     <PackageVersion>1.0.0</PackageVersion>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Build.Sql.Tests/TestData/CodeAnalyzerSample/CodeAnalyzerSample.csproj
+++ b/test/Microsoft.Build.Sql.Tests/TestData/CodeAnalyzerSample/CodeAnalyzerSample.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <DevelopmentDependency>true</DevelopmentDependency>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
To avoid bogus dependencies when `pack`ing a .dacpac

see https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/issues/669