### PR TITLE
Add check for duplicate SQL build items

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -48,8 +48,6 @@
 
   <ItemGroup>
     <!-- Build default globbing pattern includes all sql files in all subfolders, excluding bin and obj -->
-    <Build Include="**/*.sql" />
-    <Build Remove="bin/**/*.sql" />
-    <Build Remove="obj/**/*.sql" />
+    <Build Condition="'$(EnableDefaultSqlItems)' == 'true'" Include="**/*.sql" Exclude="$(DefaultSqlItemExcludes)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -73,7 +73,7 @@
   <Target Name="CheckForDuplicateSqlItems" BeforeTargets="_SetupSqlBuildInputs">
 
     <PropertyGroup>
-      <DefaultItemsMoreInformationLink>https://learn.microsoft.com/sql/tools/sql-database-projects/howto/convert-original-sql-project</DefaultItemsMoreInformationLink>
+      <DefaultItemsMoreInformationLink>https://aka.ms/upgrade-sqlproject</DefaultItemsMoreInformationLink>
     </PropertyGroup>
 
     <CheckForDuplicateItems

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -73,7 +73,7 @@
   <Target Name="CheckForDuplicateSqlItems" BeforeTargets="_SetupSqlBuildInputs">
 
     <PropertyGroup>
-      <DefaultItemsMoreInformationLink>https://aka.ms/sdkimplicititems</DefaultItemsMoreInformationLink>
+      <DefaultItemsMoreInformationLink>https://learn.microsoft.com/sql/tools/sql-database-projects/howto/convert-original-sql-project</DefaultItemsMoreInformationLink>
     </PropertyGroup>
 
     <CheckForDuplicateItems

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -68,6 +68,28 @@
   <Target Name="_CheckForUnsupportedTargetFrameworkAndFeatureCombination" />
 
   <UsingTask Condition="'$(NetCoreBuild)' == 'true'" TaskName="AllowEmptyTelemetry" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+  <UsingTask Condition="'$(NetCoreBuild)' == 'true'" TaskName="CheckForDuplicateItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
+
+  <Target Name="CheckForDuplicateSqlItems" BeforeTargets="_SetupSqlBuildInputs">
+
+    <PropertyGroup>
+      <DefaultItemsMoreInformationLink>https://aka.ms/sdkimplicititems</DefaultItemsMoreInformationLink>
+    </PropertyGroup>
+
+    <CheckForDuplicateItems
+      Items="@(Build)"
+      ItemName="Build"
+      DefaultItemsEnabled="$(EnableDefaultSqlItems)"
+      DefaultItemsOfThisTypeEnabled="$(EnableDefaultSqlItems)"
+      PropertyNameToDisableDefaultItems="EnableDefaultSqlItems"
+      MoreInformationLink="$(DefaultItemsMoreInformationLink)"
+      ContinueOnError="$(ContinueOnError)">
+      <Output TaskParameter="DeduplicatedItems" ItemName="DeduplicatedSqlItems" />
+    </CheckForDuplicateItems>
+
+    <!-- Currently do nothing with DeduplicatedItems. There are some design time logic in Microsoft.NET.Sdk.DefaultItems.Shared.targets that we can implement in the future. -->
+
+  </Target>
 
   <!-- Add dacpac file BuiltProjectOutputGroupOutput, so that it will get included in the NuGet package by the Pack target -->
   <Target Name="AddDacpacToBuiltProjectOutputGroupOutput" BeforeTargets="BuiltProjectOutputGroup">
@@ -138,4 +160,11 @@
       <ArtifactReference Include="@(_ResolvedDacpacPackageReference->'%(HintPath)')" Condition="Exists(%(_ResolvedDacpacPackageReference.HintPath))" />
     </ItemGroup>
   </Target>
+
+  <!-- Default properties to be evaluated last -->
+  <PropertyGroup>
+    <EnableDefaultSqlItems Condition=" '$(EnableDefaultSqlItems)' == '' ">true</EnableDefaultSqlItems>
+    <DefaultSqlItemExcludes>$(DefaultSqlItemExcludes);$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**</DefaultSqlItemExcludes> 
+  </PropertyGroup>
+
 </Project>

--- a/test/Microsoft.Build.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/BuildTests.cs
@@ -405,5 +405,38 @@ namespace Microsoft.Build.Sql.Tests
 
             Directory.Delete(tempFolder, true);
         }
+
+        [Test]
+        // https://github.com/microsoft/DacFx/issues/561
+        public void FailBuildOnDuplicatedItems()
+        {
+            // Add a file that should be included in the default globbing pattern already
+            this.AddBuildFiles("Table1.sql");
+
+            int exitCode = this.RunDotnetCommandOnProject("build", out _, out _);
+
+            // Verify failure
+            Assert.AreEqual(1, exitCode, "Build is expected to fail.");
+        }
+
+        [Test]
+        public void BuildWithDefaultItemsDisabled()
+        {
+            // Add a file that should be included in the default globbing pattern already
+            this.AddBuildFiles("Table1.sql");
+
+            // Disable default items
+            ProjectUtils.AddProperties(this.GetProjectFilePath(), new Dictionary<string, string>()
+            {
+                { "EnableDefaultSqlItems", "False" }
+            });
+
+            int exitCode = this.RunDotnetCommandOnProject("build", out _, out string stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+        }
     }
 }

--- a/test/Microsoft.Build.Sql.Tests/TestData/BuildWithDefaultItemsDisabled/Table1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/BuildWithDefaultItemsDisabled/Table1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[Table1]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)

--- a/test/Microsoft.Build.Sql.Tests/TestData/FailBuildOnDuplicatedItems/Table1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/FailBuildOnDuplicatedItems/Table1.sql
@@ -1,0 +1,5 @@
+CREATE TABLE [dbo].[Table1]
+(
+	c1 int NOT NULL PRIMARY KEY,
+	c2 int NULL
+)


### PR DESCRIPTION
The SDK's implicit globbing pattern (**/*.sql) may conflict with any explicit includes with metadata in the project file. Normally MSBuild is smart enough to resolve the duplicates, but the additional metadata makes it think that the items are different, which may result in a significant performance impact during the build process.

I'm adding a check similar to the [CheckForDuplicateItems target](https://github.com/dotnet/sdk/blob/e75238b3517a6565b981a171ec7e43b378fb2f76/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.DefaultItems.Shared.targets#L179) that will fail the build if any explicit includes are already covered by the default globbing pattern. Project authors would either need to remove the explicit includes or disable the default globbing pattern by setting `EnableDefaultSqlItems` to `false`. Additional metadata should be attached using Update instead:
```xml
<Build Update="Table1.sql" Metadata="Value" />
  <Metadata>Value</Metadata>
</Build>
```