### PR TITLE
Add MSBuild runtime check for CheckForDuplicateItems

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -70,7 +70,7 @@
   <UsingTask Condition="'$(NetCoreBuild)' == 'true'" TaskName="AllowEmptyTelemetry" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <UsingTask Condition="'$(NetCoreBuild)' == 'true'" TaskName="CheckForDuplicateItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
-  <Target Name="CheckForDuplicateSqlItems" BeforeTargets="_SetupSqlBuildInputs">
+  <Target Name="CheckForDuplicateSqlItems" Condition="'$(NetCoreBuild)' == 'true'" BeforeTargets="_SetupSqlBuildInputs">
 
     <PropertyGroup>
       <DefaultItemsMoreInformationLink>https://aka.ms/upgrade-sqlproject</DefaultItemsMoreInformationLink>


### PR DESCRIPTION
Fixes #577 

Only trigger `CheckForDuplicateItems` target from `dotnet build`.

There are too many MSBuild target differences between dotnet build and SSDT build. This means the check will not be triggered from SSDT, at least this unblocks the build for now.