### PR TITLE
Add tests against MSBuild

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -36,3 +36,16 @@ jobs:
         dotnet-quality: ga
     - run: dotnet build DacFx.sln
     - run: dotnet test DacFx.sln --no-build -f ${{ matrix.targetFramework }}
+  
+  msbuildTest:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup .NET ${{ env.LATEST_DOTNET_VERSION }}
+      uses: actions/setup-dotnet@v4  # Latest version is always required
+      with:
+        dotnet-version: ${{ env.LATEST_DOTNET_VERSION }}
+        dotnet-quality: preview
+    - run: dotnet build DacFx.sln
+    - run: dotnet test DacFx.sln --no-build -f net472

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
 
     <!-- Test -->
     <PackageVersion Include="Microsoft.Build" Version="16.9.0" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.9.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
     <PackageVersion Include="nunit" Version="3.13.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
 
     <!-- Test -->
     <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.11.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
     <PackageVersion Include="nunit" Version="3.13.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,10 +20,10 @@
 
     <!-- Test -->
     <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.9.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
     <PackageVersion Include="nunit" Version="3.13.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="System.IO.Packaging" Version="8.0.1" />
 
     <!-- Test -->
-    <PackageVersion Include="Microsoft.Build" Version="16.9.0" />
+    <PackageVersion Include="Microsoft.Build" Version="17.11.4" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.9.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />

--- a/src/Microsoft.Build.Sql.Templates/Microsoft.Build.Sql.Templates.csproj
+++ b/src/Microsoft.Build.Sql.Templates/Microsoft.Build.Sql.Templates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <PackageType>Template</PackageType>
     <PackageId>Microsoft.Build.Sql.Templates</PackageId>
     <Title>Microsoft.Build.Sql templates</Title>

--- a/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
+++ b/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SdkIntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\$(MSBuildThisFileName)</SdkIntermediateOutputPath>
@@ -12,7 +12,7 @@
     <PackageVersion>1.0.0-test</PackageVersion>
 
     <!-- Path where all the DLLs build depends on will be copied to -->
-    <BuildBinariesPath>$(MSBuildThisFileDirectory)\tools\net8.0\</BuildBinariesPath>
+    <BuildBinariesPath>$(MSBuildThisFileDirectory)\tools\$(TargetFramework)\</BuildBinariesPath>
 
     <!-- NuGet Package Properties -->
     <Authors>Microsoft</Authors>
@@ -43,20 +43,43 @@
     <PackageReference Include="System.IO.Packaging" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <Target Name="CopyBuildBinaries" BeforeTargets="Build">
-    <Message Text="Using DacFx version '$(DacFxPackageVersion)'" Importance="high" />
+  <Target Name="CopyNetFrameworkBinaries"
+          Condition="'$(IsCrossTargetingBuild)' != 'true' And '$(TargetFramework)' == 'net472'"
+          DependsOnTargets="ResolvePackageAssets"
+          BeforeTargets="Build">
     <ItemGroup>
-      <PackageFiles Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net8.0\*.dll" />
-      <PackageFiles Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net8.0\*.targets" />
-      <PackageFiles Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net8.0\**\*.resources.dll" />
-      <PackageFiles Include="$(PkgMicrosoft_Data_SqlClient)\lib\net6.0\Microsoft.Data.SqlClient.dll" />
-      <PackageFiles Include="$(PkgMicrosoft_SqlServer_Server)\lib\netstandard2.0\Microsoft.SqlServer.Server.dll" />
-      <PackageFiles Include="$(PkgMicrosoft_SqlServer_TransactSql_ScriptDom)\lib\net8.0\Microsoft.SqlServer.TransactSql.ScriptDom.dll" />
-      <PackageFiles Include="$(PkgMicrosoft_SqlServer_Types)\lib\netstandard2.1\Microsoft.SqlServer.Types.dll" />
-      <PackageFiles Include="$(PkgSystem_ComponentModel_Composition)\lib\net8.0\System.ComponentModel.Composition.dll" />
-      <PackageFiles Include="$(PkgSystem_IO_Packaging)\lib\net8.0\System.IO.Packaging.dll" />
+      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net472\*.dll" />
+      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net472\*.targets" />
+      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net472\**\*.resources.dll" />
+      <PackageFilesNetFx Include="$(PkgMicrosoft_Data_SqlClient)\lib\net462\Microsoft.Data.SqlClient.dll" />
+      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_Server)\lib\net46\Microsoft.SqlServer.Server.dll" />
+      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_TransactSql_ScriptDom)\lib\net462\Microsoft.SqlServer.TransactSql.ScriptDom.dll" />
+      <PackageFilesNetFx Include="$(PkgSystem_ComponentModel_Composition)\lib\netstandard2.0\System.ComponentModel.Composition.dll" />
+      <PackageFilesNetFx Include="$(PkgSystem_IO_Packaging)\lib\net462\System.IO.Packaging.dll" />
     </ItemGroup>
-    <Copy SourceFiles="@(PackageFiles)" DestinationFolder="$(BuildBinariesPath)\%(PackageFiles.RecursiveDir)" />
+    <Copy SourceFiles="@(PackageFilesNetFx)" DestinationFolder="$(BuildBinariesPath)\%(PackageFilesNetFx.RecursiveDir)" />
+  </Target>
+
+  <Target Name="CopyNetCoreBinaries"
+          Condition="'$(IsCrossTargetingBuild)' != 'true' And '$(TargetFramework)' != 'net472'"
+          DependsOnTargets="ResolvePackageAssets"
+          BeforeTargets="Build">
+    <ItemGroup>
+      <PackageFilesNetCore Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net8.0\*.dll" />
+      <PackageFilesNetCore Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net8.0\*.targets" />
+      <PackageFilesNetCore Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net8.0\**\*.resources.dll" />
+      <PackageFilesNetCore Include="$(PkgMicrosoft_Data_SqlClient)\lib\net6.0\Microsoft.Data.SqlClient.dll" />
+      <PackageFilesNetCore Include="$(PkgMicrosoft_SqlServer_Server)\lib\netstandard2.0\Microsoft.SqlServer.Server.dll" />
+      <PackageFilesNetCore Include="$(PkgMicrosoft_SqlServer_TransactSql_ScriptDom)\lib\net8.0\Microsoft.SqlServer.TransactSql.ScriptDom.dll" />
+      <PackageFilesNetCore Include="$(PkgMicrosoft_SqlServer_Types)\lib\netstandard2.1\Microsoft.SqlServer.Types.dll" />
+      <PackageFilesNetCore Include="$(PkgSystem_ComponentModel_Composition)\lib\net8.0\System.ComponentModel.Composition.dll" />
+      <PackageFilesNetCore Include="$(PkgSystem_IO_Packaging)\lib\net8.0\System.IO.Packaging.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PackageFilesNetCore)" DestinationFolder="$(BuildBinariesPath)\%(PackageFilesNetCore.RecursiveDir)" />
+  </Target>
+
+  <Target Name="IncludePackageFiles" Condition="'$(IsCrossTargetingBuild)' == 'true'" BeforeTargets="GenerateNuspec" AfterTargets="DispatchToInnerBuilds">
+    <Message Text="Using DacFx version '$(DacFxPackageVersion)'" Importance="high" />
     <ItemGroup>
       <Content Remove="tools\**" />
       <Content Include="tools\**" Pack="true" PackagePath="tools\" />
@@ -64,7 +87,7 @@
   </Target>
 
   <!-- Sets the SDK version correctly in the README -->
-  <Target Name="SetSdkAssemblyVersion" BeforeTargets="GenerateNuspec;Build">
+  <Target Name="SetSdkAssemblyVersion" Condition="'$(IsCrossTargetingBuild)' == 'true'" BeforeTargets="GenerateNuspec">
     <ItemGroup>
       <TemplateFiles Include="README.md" />
     </ItemGroup>

--- a/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
+++ b/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
@@ -43,23 +43,6 @@
     <PackageReference Include="System.IO.Packaging" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <Target Name="CopyNetFrameworkBinaries"
-          Condition="'$(IsCrossTargetingBuild)' != 'true' And '$(TargetFramework)' == 'net472'"
-          DependsOnTargets="ResolvePackageAssets"
-          BeforeTargets="Build">
-    <ItemGroup>
-      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net472\*.dll" />
-      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net472\*.targets" />
-      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_DacFx)\lib\net472\**\*.resources.dll" />
-      <PackageFilesNetFx Include="$(PkgMicrosoft_Data_SqlClient)\lib\net462\Microsoft.Data.SqlClient.dll" />
-      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_Server)\lib\net46\Microsoft.SqlServer.Server.dll" />
-      <PackageFilesNetFx Include="$(PkgMicrosoft_SqlServer_TransactSql_ScriptDom)\lib\net462\Microsoft.SqlServer.TransactSql.ScriptDom.dll" />
-      <PackageFilesNetFx Include="$(PkgSystem_ComponentModel_Composition)\lib\netstandard2.0\System.ComponentModel.Composition.dll" />
-      <PackageFilesNetFx Include="$(PkgSystem_IO_Packaging)\lib\net462\System.IO.Packaging.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(PackageFilesNetFx)" DestinationFolder="$(BuildBinariesPath)\%(PackageFilesNetFx.RecursiveDir)" />
-  </Target>
-
   <Target Name="CopyNetCoreBinaries"
           Condition="'$(IsCrossTargetingBuild)' != 'true' And '$(TargetFramework)' != 'net472'"
           DependsOnTargets="ResolvePackageAssets"

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -135,7 +135,7 @@
   <!-- Override target to skip invalid .NET Framework check -->
   <Target Name="_CheckForUnsupportedTargetFrameworkAndFeatureCombination" />
 
-  <Target Name="CheckForDuplicateSqlItems" Condition="'$(NetCoreBuild)' == 'true'" BeforeTargets="_SetupSqlBuildInputs">
+  <Target Name="CheckForDuplicateSqlItems" BeforeTargets="_SetupSqlBuildInputs">
 
     <PropertyGroup>
       <DefaultItemsMoreInformationLink>https://aka.ms/upgrade-sqlproject#required-remove-build-items-included-by-default</DefaultItemsMoreInformationLink>

--- a/test/Microsoft.Build.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/BuildTests.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Build.Sql.Tests
         {
             // Post-deployment script includes Table2.sql which creates Table2, it should not be part of the model
             this.AddPostDeployScripts("Script.PostDeployment1.sql");
-            int exitCode = this.RunDotnetCommandOnProject("build", out _, out string stdError, "-bl");
+            int exitCode = this.RunDotnetCommandOnProject("build", out _, out string stdError);
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
@@ -476,7 +476,7 @@ namespace Microsoft.Build.Sql.Tests
             DateTime lastModifiedTime = File.GetLastWriteTime(GetDacpacPath());
 
             // Run build again and verify it is incremental
-            exitCode = this.RunDotnetCommandOnProject("build", out _, out stdError, "-flp:v=diag");
+            exitCode = this.RunDotnetCommandOnProject("build", out _, out stdError, arguments: "-flp:v=diag");
             Assert.AreEqual(0, exitCode, "Second build failed with error " + stdError);
             Assert.AreEqual(string.Empty, stdError);
 
@@ -500,7 +500,7 @@ namespace Microsoft.Build.Sql.Tests
             });
 
             // Build the project and verify the target path is printed
-            int exitCode = this.RunGenericDotnetCommand("build -v d", out string stdOutput, out string stdError);
+            int exitCode = this.RunDotnetCommandOnProject("build", out string stdOutput, out string stdError);
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
             Assert.AreEqual(string.Empty, stdError);
             StringAssert.Contains($"Target path from PrintTargetPath: {GetDacpacPath()}", stdOutput, "Target path not found in output.");

--- a/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
@@ -158,12 +158,12 @@ namespace Microsoft.Build.Sql.Tests
 
 #if NETFRAMEWORK
             // dotnet command will be run as a MSBuild target and we need to specify an explicit restore
-            dotnetCommand = "-target:Restore;" + dotnetCommand;
+            dotnetCommand = "-target:" + dotnetCommand;
+            arguments += " -restore -verbosity:normal";
             string executablePath = TestUtils.MSBuildExePath;
-            arguments += " -verbosity:normal";
 #else
+            arguments += " --verbosity normal";
             string executablePath = TestUtils.DotnetPath;
-            arguments += " -v n";
 #endif
 
             ProcessStartInfo dotnetStartInfo = new ProcessStartInfo

--- a/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Build.Sql.Tests
             // Set up the dotnet process
             ProcessStartInfo dotnetStartInfo = new ProcessStartInfo
             {
-                FileName = TestUtils.GetDotnetPath(),
+                FileName = TestUtils.DotnetPath,
                 Arguments = $"{dotnetCommandWithArgs}",
                 WorkingDirectory = this.WorkingDirectory,
                 WindowStyle = ProcessWindowStyle.Hidden,
@@ -144,16 +144,32 @@ namespace Microsoft.Build.Sql.Tests
 
         /// <summary>
         /// Calls dotnet command on the database project.
+        /// In .NET Framework tests this will run msbuild.exe from VS installation.
         /// </summary>
         /// <param name="dotnetCommand">The dotnet command to run (build, pack, etc.)</param>
         /// <param name="arguments">Any additional arguments to be passed to 'dotnet build'.</param>
         /// <returns>The Exit Code of the dotnet process.</returns>
-        protected int RunDotnetCommandOnProject(string dotnetCommand, out string stdOutput, out string stdError, string arguments = "")
+        protected int RunDotnetCommandOnProject(string dotnetCommand, out string stdOutput, out string stdError, string projectPath = "", string arguments = "")
         {
+            if (string.IsNullOrEmpty(projectPath))
+            {
+                projectPath = this.GetProjectFilePath();
+            }
+
+#if NETFRAMEWORK
+            // dotnet command will be run as a MSBuild target and we need to specify an explicit restore
+            dotnetCommand = "-target:Restore;" + dotnetCommand;
+            string executablePath = TestUtils.MSBuildExePath;
+            arguments += " -verbosity:normal";
+#else
+            string executablePath = TestUtils.DotnetPath;
+            arguments += " -v n";
+#endif
+
             ProcessStartInfo dotnetStartInfo = new ProcessStartInfo
             {
-                FileName = TestUtils.GetDotnetPath(),
-                Arguments = $"{dotnetCommand} {DatabaseProjectName}.sqlproj {arguments} -v n",
+                FileName = executablePath,
+                Arguments = $"{dotnetCommand} {projectPath} {arguments}",
                 WorkingDirectory = this.WorkingDirectory,
                 WindowStyle = ProcessWindowStyle.Hidden,
                 RedirectStandardOutput = true,

--- a/test/Microsoft.Build.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
+++ b/test/Microsoft.Build.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
@@ -17,13 +17,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <!-- Fixes a MSBuild runtime issue -->
+    <!-- References needed to run MSBuild at runtime -->
+    <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="System.Text.Json" />
   </ItemGroup>
 

--- a/test/Microsoft.Build.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
+++ b/test/Microsoft.Build.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" />
     <PackageReference Include="NuGet.Packaging" />

--- a/test/Microsoft.Build.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
+++ b/test/Microsoft.Build.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
@@ -3,10 +3,13 @@
   <PropertyGroup>
     <!-- Multi-targeting to test SDK on different .NET versions, requires all of the following SDKs to be installed. -->
     <!-- To build and test only one version, add -f to dotnet command. -->
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
     <!-- Disable EOL target framework check since we're explicitly testing against older .NET versions. -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    
+    <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" />
     <PackageReference Include="NuGet.Packaging" />
@@ -26,6 +30,12 @@
   <ItemGroup>
     <Content Include="TestData/**" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="Template/**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <!-- .NET Core only tests -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Compile Remove="PublishTests.cs" />
+    <Compile Remove="TemplateTests.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Build.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
+++ b/test/Microsoft.Build.Sql.Tests/Microsoft.Build.Sql.Tests.csproj
@@ -8,8 +8,6 @@
     <LangVersion>latest</LangVersion>
     <!-- Disable EOL target framework check since we're explicitly testing against older .NET versions. -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    
-    <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,12 +17,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" />
-    <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <!-- Fixes a MSBuild runtime issue -->
+    <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,6 +33,7 @@
 
   <!-- .NET Core only tests -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Compile Remove="CodeAnalysisTests.cs" />
     <Compile Remove="PublishTests.cs" />
     <Compile Remove="TemplateTests.cs" />
   </ItemGroup>

--- a/test/Microsoft.Build.Sql.Tests/PackTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/PackTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Sql.Tests
         public void VerifySimplePack()
         {
             string stdOutput, stdError;
-            int exitCode = this.RunGenericDotnetCommand("pack -c Debug", out stdOutput, out stdError);
+            int exitCode = RunDotnetCommandOnProject("pack", out stdOutput, out stdError, arguments: "-p:Configuration=Debug");
 
             // Verify success
             Assert.AreEqual(0, exitCode, "Pack failed with error " + stdError);
@@ -34,13 +34,17 @@ namespace Microsoft.Build.Sql.Tests
         {
             // Run build first
             string stdOutput, stdError;
-            int exitCode = this.RunGenericDotnetCommand("build", out stdOutput, out stdError);
+            int exitCode = RunDotnetCommandOnProject("build", out stdOutput, out stdError);
             Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
             Assert.AreEqual(string.Empty, stdError);
             this.VerifyDacPackage();
 
-            // Run pack with --no-build
-            exitCode = this.RunGenericDotnetCommand("pack -c Debug --no-build", out stdOutput, out stdError);
+            // Run pack with --no-build or -p:NoBuild=true
+#if NETFRAMEWORK
+            exitCode = RunDotnetCommandOnProject("pack", out stdOutput, out stdError, arguments: "-p:Configuration=Debug -p:NoBuild=true");
+#else
+            exitCode = RunDotnetCommandOnProject("pack", out stdOutput, out stdError, arguments: "-c Debug --no-build");
+#endif
             Assert.AreEqual(0, exitCode, "Pack failed with error " + stdError);
             Assert.AreEqual(string.Empty, stdError);
             this.VerifyNugetPackage();
@@ -71,7 +75,7 @@ namespace Microsoft.Build.Sql.Tests
 
             // Pack
             string stdOutput, stdError;
-            int exitCode = this.RunGenericDotnetCommand("pack -c Debug", out stdOutput, out stdError);
+            int exitCode = RunDotnetCommandOnProject("pack", out stdOutput, out stdError, "-p:Configuration=Debug");
 
             // Verify
             Assert.AreEqual(0, exitCode, "Pack failed with error " + stdError);
@@ -123,7 +127,7 @@ namespace Microsoft.Build.Sql.Tests
 
             // Run dotnet pack
             string stdOutput, stdError;
-            int exitCode = this.RunGenericDotnetCommand("pack -c Debug", out stdOutput, out stdError);
+            int exitCode = RunDotnetCommandOnProject("pack", out stdOutput, out stdError, arguments: "-p:Configuration=Debug");
 
             // Verify
             Assert.AreEqual(0, exitCode, "Pack failed with error " + stdError);
@@ -133,7 +137,7 @@ namespace Microsoft.Build.Sql.Tests
                 var files = package.GetFiles();
                 Assert.IsTrue(files.Any(f => f.Equals("content/include_content.txt", StringComparison.OrdinalIgnoreCase)),
                     "Expected content/include_content.txt to be in the packaged file list.");
-                Assert.IsFalse(files.Any(f => f.Contains("exclude_content.txt", StringComparison.OrdinalIgnoreCase)),
+                Assert.IsFalse(files.Any(f => f.Contains("exclude_content.txt")),
                     "Expected exclude_content.txt to be excluded from the packaged file list.");
                 Assert.IsTrue(files.Any(f => f.Equals("tools/none.txt", StringComparison.OrdinalIgnoreCase)),
                     "Expected tools/none.txt to be in the packaged file list.");

--- a/test/Microsoft.Build.Sql.Tests/PackageReferenceTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/PackageReferenceTests.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Build.Sql.Tests
             // Build, pack, and verify output
             string stdOutput, stdError;
             string packagesFolder = Path.Combine(this.WorkingDirectory, "pkg");
-            int exitCode = this.RunGenericDotnetCommand($"pack {ReferenceProjectName}/{ReferenceProjectName}.sqlproj -p:Version={ReferencePackageVersion} -o \"{packagesFolder}\"", out stdOutput, out stdError);
+            int exitCode = RunDotnetCommandOnProject("pack", out stdOutput, out stdError,
+                projectPath: $"{ReferenceProjectName}/{ReferenceProjectName}.sqlproj",
+                arguments: $"-p:Version={ReferencePackageVersion} -p:OutputPath=\"{packagesFolder}\"");
 
             Assert.AreEqual(0, exitCode, "dotnet pack failed with error " + stdError);
             Assert.AreEqual(string.Empty, stdError);

--- a/test/Microsoft.Build.Sql.Tests/TestUtils.cs
+++ b/test/Microsoft.Build.Sql.Tests/TestUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Build.Sql.Tests
@@ -16,33 +17,55 @@ namespace Microsoft.Build.Sql.Tests
         /// Returns the full path to the dotnet executable based on the current operating system.
         /// Path to dotnet tool can be set by build pipelines via DotnetToolPathEnvironmentVariable.
         /// </summary>
-        public static string GetDotnetPath()
+        public static string DotnetPath
         {
-            string dotnetExecutable = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
-            string? dotnetPath = Environment.GetEnvironmentVariable(DotnetToolPathEnvironmentVariable) ?? Environment.GetEnvironmentVariable(DotnetRootEnvironmentVariable);
-            if (string.IsNullOrEmpty(dotnetPath))
+            get
             {
-                // Determine OS specific dotnet installation path
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                string dotnetExecutable = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+                string? dotnetPath = Environment.GetEnvironmentVariable(DotnetToolPathEnvironmentVariable) ?? Environment.GetEnvironmentVariable(DotnetRootEnvironmentVariable);
+                if (string.IsNullOrEmpty(dotnetPath))
                 {
-                    dotnetPath = @"C:\Program Files\dotnet";
+                    // Determine OS specific dotnet installation path
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        dotnetPath = @"C:\Program Files\dotnet";
+                    }
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    {
+                        dotnetPath = "/usr/share/dotnet";
+                    }
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    {
+                        dotnetPath = "/usr/local/share/dotnet";
+                    }
+                    else
+                    {
+                        throw new NotSupportedException("Tests are currently not supported on " + RuntimeInformation.OSDescription);
+                    }
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    dotnetPath = "/usr/share/dotnet";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    dotnetPath = "/usr/local/share/dotnet";
-                }
-                else
-                {
-                    throw new NotSupportedException("Tests are currently not supported on " + RuntimeInformation.OSDescription);
-                }
-            }
 
-            return Path.Combine(dotnetPath, dotnetExecutable);
+                return Path.Combine(dotnetPath, dotnetExecutable);
+            }
         }
+
+#if NETFRAMEWORK
+        /// <summary>
+        /// Returns the full path to the MSBuild executable based on Visual Studio installation.
+        /// </summary>
+        public static string MSBuildExePath
+        {
+            get
+            {
+                var vsInstance = Microsoft.Build.Locator.MSBuildLocator.QueryVisualStudioInstances().FirstOrDefault();
+                if (vsInstance == null)
+                {
+                    throw new InvalidOperationException("No Visual Studio instance found.");
+                }
+
+                return Path.Combine(vsInstance.MSBuildPath, "MSBuild.exe");
+            }
+        }
+#endif
 
         /// <summary>
         /// Copies all files and subdirectories from <paramref name="sourceDirectoryPath"/> to <paramref name="targetDirectoryPath"/>.


### PR DESCRIPTION
Add .NET Framework tests to simulate building in Visual Studio, requires SSDT installation right now.
Need to multi target SDK and templates projects for the .NET Framework dependency.