### PR TITLE
Use DacFx 170.1.23-preview

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <!-- Let CI pipelines to set these for testing dependencies -->
-    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">170.0.94</DacFxPackageVersion>
+    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">170.1.23-preview</DacFxPackageVersion>
     <ScriptDomPackageVersion Condition="'$(ScriptDomPackageVersion)' == ''">170.18.0</ScriptDomPackageVersion>
     <SqlClientPackageVersion Condition="'$(SqlClientPackageVersion)' == ''">5.1.6</SqlClientPackageVersion>
   </PropertyGroup>

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -132,6 +132,13 @@
   <Import Condition="'$(NetCoreBuild)' != 'true' AND Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets')"
           Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets" />
 
+  <ItemGroup>
+    <!-- Capture SDK version in telemetry -->
+    <DacFxTelemetryItems Update="$(MSBuildProjectFullPath)">
+      <MicrosftBuildSqlVersion>$(MicrosoftBuildSqlVersion)</MicrosftBuildSqlVersion>
+    </DacFxTelemetryItems>
+  </ItemGroup>
+
   <!-- Override target to skip invalid .NET Framework check -->
   <Target Name="_CheckForUnsupportedTargetFrameworkAndFeatureCombination" />
 


### PR DESCRIPTION
# Description

Update to DacFx 170.1.23-preview which brings in a fix for including extra assemblies in the Nuget package, and has a hook to capture SDK version in telemetry.

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
