### PR TITLE
Add release notes for Microsoft.Build.Sql 2.0.0-preview.3

### DIFF
--- a/release-notes/Microsoft.Build.Sql/2.0.0-preview.3.md
+++ b/release-notes/Microsoft.Build.Sql/2.0.0-preview.3.md
@@ -1,0 +1,16 @@
+# Release Notes
+
+## Microsoft.Build.Sql 2.0.0-preview.3 - 2025-08-01
+
+This update brings the below changes over the previous release:
+
+### Added
+* Added .NET Framework build binaries to the SDK, which will be used by default by MSBuild.exe. This can be overridden by setting `BuildFromSSDT` to `true` which will revert to using SSDT binaries. [#672](https://github.com/microsoft/DacFx/pull/672)
+
+### Changed
+* Updated DacFx version to 170.1.61. [#673](https://github.com/microsoft/DacFx/pull/673)
+
+### Fixed
+* Fixed incremental builds being skipped when files are deleted. [#668](https://github.com/microsoft/DacFx/pull/668)
+* Fixed an issue where project build fails on `CREATE USER` with SID/TYPE. [#632](https://github.com/microsoft/DacFx/issues/632)
+* Fixed build error with scalar functions and identity columns on Fabric DW.

--- a/release-notes/Microsoft.Build.Sql/README.md
+++ b/release-notes/Microsoft.Build.Sql/README.md
@@ -4,6 +4,7 @@ The following Microsoft.Build.Sql and Microsoft.Build.Sql.Templates releases hav
 
 | Release Date | Version | Notes |
 | :-- | :-- | :--: |
+| 2025-08-01 | 2.0.0-preview.3 | [release notes](2.0.0-preview.3.md) |
 | 2025-06-03 | 2.0.0-preview.2 | [release notes](2.0.0-preview.2.md) |
 | 2025-04-18 | 2.0.0-preview.1 | [release notes](2.0.0-preview.1.md) |
 | 2025-03-11 | 1.0.0 | [release notes](1.0.0.md) |


### PR DESCRIPTION
# Description

Add release notes for SDK 2.0.0-preview.3

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
