### PR TITLE
Drskwier/templates cleanup

### DIFF
--- a/src/Microsoft.Build.Sql.Templates/sqlcodeanalysis/.template.config/ide.host.json
+++ b/src/Microsoft.Build.Sql.Templates/sqlcodeanalysis/.template.config/ide.host.json
@@ -1,0 +1,7 @@
+{
+    "unsupportedHosts": [
+        {
+            "id": "vs"
+        }
+    ]
+}

--- a/src/Microsoft.Build.Sql.Templates/sqlproject/.template.config/ide.host.json
+++ b/src/Microsoft.Build.Sql.Templates/sqlproject/.template.config/ide.host.json
@@ -1,0 +1,7 @@
+{
+    "unsupportedHosts": [
+        {
+            "id": "vs"
+        }
+    ]
+}

--- a/src/Microsoft.Build.Sql.Templates/sqlproject/.template.config/template.json
+++ b/src/Microsoft.Build.Sql.Templates/sqlproject/.template.config/template.json
@@ -7,7 +7,7 @@
     ],
     "identity": "Microsoft.Build.Sql.Project",
     "name": "SQL Server Database Project",
-    "description": "A project that creates a SQL Server Data-Tier Application package (.dacpac)",
+    "description": "A Microsoft.Build.Sql project that creates a SQL Server Data-Tier Application package (.dacpac)",
     "shortName": "sqlproj",
     "tags": {
         "language": "SQL",

--- a/src/Microsoft.Build.Sql.Templates/sqlproject/README.md
+++ b/src/Microsoft.Build.Sql.Templates/sqlproject/README.md
@@ -12,10 +12,10 @@ dotnet build
 
 ## Publish
 
-To publish the project, the SqlPackage CLI or the SQL Database Projects extension for Azure Data Studio/VS Code is required. The following command will publish the project to a local SQL Server instance:
+To publish the project, the SqlPackage CLI or the SQL Database Projects extension for VS Code is required. The following command will publish the project to a local SQL Server instance:
 
 ```bash
-./SqlPackage /Action:Publish /SourceFile:bin/Debug/SqlProject1.dacpac /TargetServerName:localhost /TargetDatabaseName:SqlProject1
+sqlpackage /Action:Publish /SourceFile:bin/Debug/SqlProject1.dacpac /TargetServerName:localhost /TargetDatabaseName:SqlProject1
 ```
 
 Learn more about authentication and other options for SqlPackage here: https://aka.ms/sqlpackage-ref


### PR DESCRIPTION
# Description

https://github.com/microsoft/DacFx/issues/675

- adds sdk name to template description
- hides both templates from the VS new project dialog

# Code Changes

- [x] [Unit tests](/test/) are added, if possible
- [x] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [x] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [x] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [x] Use proper logging for MSBuild tasks
