### PR TITLE
Default HideAbsolutePath to true when using PackageReferences

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -242,6 +242,9 @@
         <DatabaseVariableLiteralValue Condition="'%(_ResolvedDacpacPackageReference.DatabaseVariableLiteralValue)' == '' And '%(_ResolvedDacpacPackageReference.IsMasterDacpac)' == 'true'">master</DatabaseVariableLiteralValue>
         <DatabaseVariableLiteralValue Condition="'%(_ResolvedDacpacPackageReference.DatabaseVariableLiteralValue)' == '' And '%(_ResolvedDacpacPackageReference.IsMsdbDacpac)' == 'true'">msdb</DatabaseVariableLiteralValue>
         <SuppressMissingDependenciesErrors>%(PackageReference.SuppressMissingDependenciesErrors)</SuppressMissingDependenciesErrors>
+
+        <HideAbsolutePath Condition="'%(PackageReference.HideAbsolutePath)' != ''">'%(PackageReference.HideAbsolutePath)</HideAbsolutePath>
+        <HideAbsolutePath Condition="'%(PackageReference.HideAbsolutePath)' == ''">true</HideAbsolutePath>
       </_ResolvedDacpacPackageReference>
 
       <ArtifactReference Include="@(_ResolvedDacpacPackageReference->'%(HintPath)')" Condition="Exists(%(_ResolvedDacpacPackageReference.HintPath))" />

--- a/test/Microsoft.Build.Sql.Tests/PackageReferenceTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/PackageReferenceTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Build.Sql.Tests
             string tempPath = TestUtils.CreateTempDirectory();
             package.Unpack(tempPath);
             string modelXml = File.ReadAllText(Path.Combine(tempPath, "model.xml"));
-            StringAssert.Contains(@"<Metadata Name=""FileName"" Value=""master.dacpac"" />", modelXml, "The master.dacpac path should not be absolute in the model.xml file.");
+            StringAssert.IsMatch(@"<Metadata Name=""FileName"" Value=""(master.dacpac|MASTER.DACPAC)"" />", modelXml, "The master.dacpac path should not be absolute in the model.xml file.");
         }
 
         [Test]
@@ -161,12 +161,12 @@ namespace Microsoft.Build.Sql.Tests
             Assert.AreEqual(string.Empty, stdError);
             this.VerifyDacPackage();
 
-            // Verify that the master.dacpac path is not absolute in the generated model.xml
+            // Verify that the master.dacpac path is absolute in the generated model.xml
             using DacPackage package = DacPackage.Load(GetDacpacPath());
             string tempPath = TestUtils.CreateTempDirectory();
             package.Unpack(tempPath);
             string modelXml = File.ReadAllText(Path.Combine(tempPath, "model.xml"));
-            StringAssert.IsMatch(@"<Metadata Name=""FileName"" Value=""(.+)master.dacpac"" />", modelXml, "The master.dacpac path should be absolute in the model.xml file when HideAbsolutePath is false.");
+            StringAssert.IsMatch(@"<Metadata Name=""FileName"" Value=""(.+)(master.dacpac|MASTER.DACPAC)"" />", modelXml, "The master.dacpac path should be absolute in the model.xml file when HideAbsolutePath is false.");
         }
     }
 }

--- a/test/Microsoft.Build.Sql.Tests/PackageReferenceTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/PackageReferenceTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.SqlServer.Dac;
 using NUnit.Framework;
 
 namespace Microsoft.Build.Sql.Tests
@@ -25,7 +26,7 @@ namespace Microsoft.Build.Sql.Tests
         {
             // Copy the reference project folder to working directory
             TestUtils.CopyDirectoryRecursive(Path.Combine(CommonTestDataDirectory, ReferenceProjectName), Path.Combine(WorkingDirectory, ReferenceProjectName));
-            
+
             // Build, pack, and verify output
             string stdOutput, stdError;
             string packagesFolder = Path.Combine(this.WorkingDirectory, "pkg");
@@ -124,6 +125,48 @@ namespace Microsoft.Build.Sql.Tests
             Assert.AreEqual(string.Empty, stdError);
             this.VerifyDacPackage();
             FileAssert.Exists(Path.Combine(this.GetOutputDirectory(), $"{DatabaseProjectName}_Create.sql"));
+        }
+
+        [Test]
+        [Description("Verifies HideAbsolutePath property is set to true by default for package references")]
+        public void VerifyHideAbsolutePathPropertyDefault()
+        {
+            // Add PackageReference to master.dacpac and build
+            this.AddPackageReference(packageName: "Microsoft.SqlServer.Dacpacs.Master", version: "160.*");
+            int exitCode = this.RunDotnetCommandOnProject("build", out _, out string stdError);
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Verify that the master.dacpac path is not absolute in the generated model.xml
+            using DacPackage package = DacPackage.Load(GetDacpacPath());
+            string tempPath = TestUtils.CreateTempDirectory();
+            package.Unpack(tempPath);
+            string modelXml = File.ReadAllText(Path.Combine(tempPath, "model.xml"));
+            StringAssert.Contains(@"<Metadata Name=""FileName"" Value=""master.dacpac"" />", modelXml, "The master.dacpac path should not be absolute in the model.xml file.");
+        }
+
+        [Test]
+        [Description("Verifies that HideAbsolutePath property can be overridden to false for package references")]
+        public void VerifyHideAbsolutePathPropertyOverride()
+        {
+            // Add PackageReference to master.dacpac and build
+            ProjectUtils.AddItemGroup(GetProjectFilePath(), "PackageReference", ["Microsoft.SqlServer.Dacpacs.Master"], item =>
+            {
+                item.AddMetadata("Version", "160.*");
+                item.AddMetadata("HideAbsolutePath", "false");
+            });
+            int exitCode = this.RunDotnetCommandOnProject("build", out _, out string stdError);
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Verify that the master.dacpac path is not absolute in the generated model.xml
+            using DacPackage package = DacPackage.Load(GetDacpacPath());
+            string tempPath = TestUtils.CreateTempDirectory();
+            package.Unpack(tempPath);
+            string modelXml = File.ReadAllText(Path.Combine(tempPath, "model.xml"));
+            StringAssert.IsMatch(@"<Metadata Name=""FileName"" Value=""(.+)master.dacpac"" />", modelXml, "The master.dacpac path should be absolute in the model.xml file when HideAbsolutePath is false.");
         }
     }
 }


### PR DESCRIPTION
# Description

The absolute path to reference dacpacs is serialized by default (#329). For package references, this path resolves to somewhere in the Nuget cache, which isn't very useful. This change will set `HideAbsolutePath` to true by default in the underlying dacpac reference.

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [x] [Unit tests](/test/) are added, if possible
- [x] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [x] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [x] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [x] Use proper logging for MSBuild tasks
