### PR TITLE
Update DacFx to 170.2.37-preview

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <!-- Let CI pipelines to set these for testing dependencies -->
-    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">170.1.61</DacFxPackageVersion>
-    <ScriptDomPackageVersion Condition="'$(ScriptDomPackageVersion)' == ''">170.64.0</ScriptDomPackageVersion>
+    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">170.2.37-preview</DacFxPackageVersion>
+    <ScriptDomPackageVersion Condition="'$(ScriptDomPackageVersion)' == ''">170.82.0</ScriptDomPackageVersion>
     <SqlClientPackageVersion Condition="'$(SqlClientPackageVersion)' == ''">5.1.6</SqlClientPackageVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
# Description

Update DacFx and ScriptDom dependencies

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
