### PR TITLE
Upgrading package versions to follow the security advisory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Source -->
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.31" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
     <PackageVersion Include="Microsoft.SqlServer.DacFx" Version="$(DacFxPackageVersion)" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="$(SqlClientPackageVersion)" />
     <PackageVersion Include="Microsoft.SqlServer.Server" Version="1.0.0" />
@@ -21,8 +21,8 @@
     <PackageVersion Include="System.IO.Packaging" Version="8.0.1" />
 
     <!-- Test -->
-    <PackageVersion Include="Microsoft.Build" Version="17.11.31" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.11.31" />
+    <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.11.48" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="NuGet.Packaging" Version="6.13.2" />


### PR DESCRIPTION
# Description

This PR updates the below version of the packages to vulnerability fixed versions
- Upgrade Microsoft.Build from 17.11.31 to 17.11.48 to fix the vulnerability.
- Upgrade Microsoft.Build.Tasks.Core from 17.11.31 to 17.11.48 to fix the vulnerability.
- Upgrade Microsoft.Build.Utilities.Core from 17.11.31 to 17.11.48 to fix the vulnerability.

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
