### PR TITLE
project type guid and tests

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -100,6 +100,9 @@
     <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
     <OutputType>Database</OutputType>
     
+    <!-- Project type GUID for dotnet sln add support -->
+    <DefaultProjectTypeGuid>{42EA0DBD-9CF1-443E-919E-BE9C484E4577}</DefaultProjectTypeGuid>
+    
     <!-- Optional -->
     <IncludeCompositeObjects>True</IncludeCompositeObjects>
     

--- a/test/Microsoft.Build.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/BuildTests.cs
@@ -500,5 +500,65 @@ namespace Microsoft.Build.Sql.Tests
             this.VerifyDacPackage();
             FileAssert.Exists(NuGetClient.GetVersionCacheFilePath("Microsoft.Build.Sql"), "Version cache file should exist after fetching the version.");
         }
+
+#if !NETFRAMEWORK
+        [Test]
+        [Description("Verifies that a SQL project can be added to a .sln solution and built via dotnet sln add.")]
+        public void VerifySolutionAddAndBuild()
+        {
+            // Create a new solution
+            int exitCode = this.RunGenericDotnetCommand("new sln -n SDKTestSolution --format sln", out string stdOutput, out string stdError);
+            Assert.AreEqual(0, exitCode, "Solution creation failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+
+            // Add the existing test project to the solution
+            string projectPath = Path.GetFileName(this.GetProjectFilePath());
+            exitCode = this.RunGenericDotnetCommand($"sln SDKTestSolution.sln add {projectPath}", out stdOutput, out stdError);
+            Assert.AreEqual(0, exitCode, "Adding project to solution failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            StringAssert.Contains("added to the solution", stdOutput, "Expected success message not found.");
+
+            // Verify the solution file contains our project
+            string slnContent = File.ReadAllText(Path.Combine(this.WorkingDirectory, "SDKTestSolution.sln"));
+            StringAssert.Contains(".sqlproj", slnContent, "Project not found in solution file.");
+
+            // Build the solution
+            exitCode = this.RunGenericDotnetCommand("build SDKTestSolution.sln --verbosity normal", out stdOutput, out stdError);
+            Assert.AreEqual(0, exitCode, "Solution build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+
+            // Verify dacpac was created
+            this.VerifyDacPackage();
+        }
+
+        [Test]
+        [Description("Verifies that a SQL project can be added to a .slnx solution and built via dotnet sln add.")]
+        public void VerifySolutionAddAndBuildSlnx()
+        {
+            // Create a new solution using slnx format
+            int exitCode = this.RunGenericDotnetCommand("new sln -n SDKTestSolution --format slnx", out string stdOutput, out string stdError);
+            Assert.AreEqual(0, exitCode, "Solution creation failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+
+            // Add the existing test project to the solution
+            string projectPath = Path.GetFileName(this.GetProjectFilePath());
+            exitCode = this.RunGenericDotnetCommand($"sln SDKTestSolution.slnx add {projectPath}", out stdOutput, out stdError);
+            Assert.AreEqual(0, exitCode, "Adding project to solution failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            StringAssert.Contains("added to the solution", stdOutput, "Expected success message not found.");
+
+            // Verify the solution file contains our project
+            string slnxContent = File.ReadAllText(Path.Combine(this.WorkingDirectory, "SDKTestSolution.slnx"));
+            StringAssert.Contains(".sqlproj", slnxContent, "Project not found in solution file.");
+
+            // Build the solution
+            exitCode = this.RunGenericDotnetCommand("build SDKTestSolution.slnx --verbosity normal", out stdOutput, out stdError);
+            Assert.AreEqual(0, exitCode, "Solution build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+
+            // Verify dacpac was created
+            this.VerifyDacPackage();
+        }
+#endif
     }
 }


### PR DESCRIPTION
# Description

fixes #740 with the project type guid we added to slngen (https://github.com/microsoft/slngen/pull/623/files) and documented (https://learn.microsoft.com/en-us/sql/tools/sql-database-projects/howto/convert-original-sql-project?view=sql-server-ver17&pivots=sq1-visual-studio-code)


follows the logic expected by the .NET SDK - https://github.com/search?q=repo%3Adotnet%2Fsdk+DefaultProjectTypeGuid&type=code


ran into some mono issues with .NET Framework locally and the sln test, so both tests are .NET 8+ only

*Please provide a detailed description. Be as descriptive as possible - include information about what is being changed,
why it's being changed, and any links to relevant issues. If this is closing an existing issue use one of the [issue linking keywords](https://docs.github.com/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to link the issue to this PR and have it automatically close when completed.*

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [x] [Unit tests](/test/) are added, if possible
- [x] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [x] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [x] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [x] Use proper logging for MSBuild tasks
