### PR TITLE
Rename ssdtprojectsystem.targets to SQLProjectsSystem.targets

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -134,7 +134,7 @@
           Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets" />
 
   <!-- Use generic SQLProjectsSystem.targets for builds using SSMS/Other IDEs which supports SDK Style Projects. 
-  It is impossible for both of these targets file to exist simulataneously on its own. -->
+  It is impossible for both of these targets file to exist simultaneously on their own. -->
   <Import Condition="'$(NetCoreBuild)' != 'true' AND !Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets') AND Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\SQLProjectsSystem.targets')"
           Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\SQLProjectsSystem.targets" />
 


### PR DESCRIPTION
# Description

Adds support for the new SQLProjectsSystem.targets file used by SSMS and other IDEs, while maintaining backward compatibility with the existing ssdtprojectsystem.targets used by SSDT.

**Background**
The original ssdtprojectsystem.targets was specific to SSDT (SQL Server Data Tools). As SDK-style SQL projects are now supported by additional products like SSMS, a more generic SQLProjectsSystem.targets file is being introduced by those products.

**Changes**
*Updated the import logic in Sdk.targets to:*

Import ssdtprojectsystem.targets when it exists (SSDT installed) and SQLProjectsSystem.targets does not exist
Import SQLProjectsSystem.targets when it exists (SSMS/other IDEs installed) and ssdtprojectsystem.targets does not exist
These two targets files are mutually exclusive by design - only one will exist on a machine depending on which product is installed.

Backward Compatibility
- No breaking changes - existing SSDT installations continue to work as before
- The SDK automatically detects which targets file is available and uses the appropriate one
- No action required from the customers.


# Code Changes

- [x] [Unit tests](https://github.com/microsoft/DacFx/tree/main/test/Microsoft.Build.Sql.Tests) are added, if possible - N/A
- [x] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [x] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [x] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [x] Use proper logging for MSBuild tasks
