### PR TITLE
Change default TargetFramework from net472 to netstandard2.1 for non-…

### DIFF
--- a/src/Microsoft.Build.Sql/sdk/Sdk.props
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.props
@@ -9,7 +9,7 @@
     <UsingMicrosoftBuildSqlSdk>true</UsingMicrosoftBuildSqlSdk>
     <MicrosoftBuildSqlVersion>###ASSEMBLY_VERSION###</MicrosoftBuildSqlVersion>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
-    
+
     <!-- Output properties -->
     <TargetExt>.dacpac</TargetExt>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -35,7 +35,7 @@
 
     <!-- Don't generate editor config file -->
     <GenerateMSBuildEditorConfigFile Condition="'$(GenerateMSBuildEditorConfigFile)' == ''">false</GenerateMSBuildEditorConfigFile>
-    
+
     <!-- Don't log the high priority message mentioning this project's name (or copy the product we didn't build). -->
     <SkipCopyBuildProduct Condition="'$(SkipCopyBuildProduct)' == ''">true</SkipCopyBuildProduct>
 
@@ -43,7 +43,7 @@
     <AutomaticallyUseReferenceAssemblyPackages Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
     <NoCompilerStandardLib Condition="'$(NoCompilerStandardLib)' == ''">false</NoCompilerStandardLib>
     <NoStdLib Condition="'$(NoStdLib)' == ''">true</NoStdLib>
-    
+
     <!-- Disable Visual Studio's Fast Up-to-date Check and rely on MSBuild to determine -->
     <DisableFastUpToDateCheck Condition="'$(DisableFastUpToDateCheck)' == ''">true</DisableFastUpToDateCheck>
 
@@ -85,11 +85,11 @@
 
   <!-- building in Visual Studio requires some sort of TargetFrameworkVersion. So we condition to NetCoreBuild as false to avoid failures -->
   <PropertyGroup Condition="'$(NetCoreBuild)'=='false'">
-    <TargetFramework>net472</TargetFramework>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <TargetFrameworkMoniker>.NETFramework,Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">netstandard2.1</TargetFramework>
+    <TargetFrameworkVersion Condition="'$(TargetFrameworkVersion)' == ''">v2.1</TargetFrameworkVersion>
+    <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == ''">.NETStandard,Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>
   </PropertyGroup>
-  
+
   <!-- Defaults from SSDT -->
   <PropertyGroup>
     <!-- Required -->
@@ -99,13 +99,13 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
     <OutputType>Database</OutputType>
-    
+
     <!-- Project type GUID for dotnet sln add support -->
     <DefaultProjectTypeGuid>{42EA0DBD-9CF1-443E-919E-BE9C484E4577}</DefaultProjectTypeGuid>
-    
+
     <!-- Optional -->
     <IncludeCompositeObjects>True</IncludeCompositeObjects>
-    
+
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -14,8 +14,10 @@
     <CustomBeforeMicrosoftCommonTargets Condition="'$(ManagedLanguageTargetsGotImported)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')">$(CustomBeforeMicrosoftCommonTargets);$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
 
-  <!-- If the user overrode TargetFramework from the netstandard2.1 default (e.g. net472, net48),
-       clear the TFV/TFM that Sdk.props pre-set so Microsoft.NET.Sdk can infer the correct values. -->
+  <!-- Sdk.props pre-sets TargetFrameworkVersion and TargetFrameworkMoniker for VS design-time support.
+       When TargetFramework differs from the default (netstandard2.1), these pre-set values are stale.
+       Clear them so Microsoft.NET.Sdk's TargetFrameworkInference.targets (imported below) can
+       derive the correct values from the actual TargetFramework. -->
   <PropertyGroup Condition="'$(NetCoreBuild)'=='false' AND '$(TargetFramework)' != 'netstandard2.1'">
     <TargetFrameworkVersion />
     <TargetFrameworkMoniker />

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -14,12 +14,11 @@
     <CustomBeforeMicrosoftCommonTargets Condition="'$(ManagedLanguageTargetsGotImported)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')">$(CustomBeforeMicrosoftCommonTargets);$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
 
-  <!-- When user opts into .NET Framework for SQLCLR assemblies, override the TFV/TFM that was
-       defaulted to .NETStandard in Sdk.props. At this point the project body has been evaluated,
-       so $(TargetFramework) reflects any user customization. -->
-  <PropertyGroup Condition="'$(NetCoreBuild)'=='false' AND '$(TargetFramework)' == 'net472'">
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <TargetFrameworkMoniker>.NETFramework,Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>
+  <!-- If the user overrode TargetFramework from the netstandard2.1 default (e.g. net472, net48),
+       clear the TFV/TFM that Sdk.props pre-set so Microsoft.NET.Sdk can infer the correct values. -->
+  <PropertyGroup Condition="'$(NetCoreBuild)'=='false' AND '$(TargetFramework)' != 'netstandard2.1'">
+    <TargetFrameworkVersion />
+    <TargetFrameworkMoniker />
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />

--- a/src/Microsoft.Build.Sql/sdk/Sdk.targets
+++ b/src/Microsoft.Build.Sql/sdk/Sdk.targets
@@ -13,7 +13,15 @@
     <!-- For CPS/VS support. See https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
     <CustomBeforeMicrosoftCommonTargets Condition="'$(ManagedLanguageTargetsGotImported)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')">$(CustomBeforeMicrosoftCommonTargets);$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
-  
+
+  <!-- When user opts into .NET Framework for SQLCLR assemblies, override the TFV/TFM that was
+       defaulted to .NETStandard in Sdk.props. At this point the project body has been evaluated,
+       so $(TargetFramework) reflects any user customization. -->
+  <PropertyGroup Condition="'$(NetCoreBuild)'=='false' AND '$(TargetFramework)' == 'net472'">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkMoniker>.NETFramework,Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>
+  </PropertyGroup>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
 
   <PropertyGroup>
@@ -29,11 +37,11 @@
       IncrementalClean;
       PostBuildEvent
     </CoreBuildDependsOn>
-    
+
     <!-- Disable symbol generation -->
     <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
-    
+
     <!-- Don't emit a reference assembly -->
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 
@@ -43,7 +51,7 @@
     <!-- Default language to C# mainly for code analyzer packages -->
     <Language>C#</Language>
   </PropertyGroup>
-  
+
   <!-- Clear output group items which are read by the IDE and NuGet. -->
   <ItemGroup>
     <BuiltProjectOutputGroupKeyOutput Remove="@(BuiltProjectOutputGroupKeyOutput)" />
@@ -52,7 +60,7 @@
     <IntermediateRefAssembly Remove="@(IntermediateRefAssembly)" />
     <Reference Remove="mscorlib" />
   </ItemGroup>
-  
+
   <!--
     The CopyFilesToOutputDirectory target is hard coded to depend on ComputeIntermediateSatelliteAssemblies.  Database projects do no generate resource assemblies
     so the target is replaced with a no-op
@@ -64,8 +72,8 @@
   -->
   <Target Name="GetFrameworkPaths" DependsOnTargets="$(GetFrameworkPathsDependsOn)" />
   <Target Name="GetReferenceAssemblyPaths" DependsOnTargets="$(GetReferenceAssemblyPathsDependsOn)" />
-  
-  <!-- 
+
+  <!--
     Microsoft.Managed.Targets is imported by the managed language target files in MSBuild 16.0 and above, but most of the msbuild tasks are actually in Microsoft.Common.Currentversion.targets.
     So import it when the managed targets do not get imported.
   -->
@@ -133,7 +141,7 @@
   <Import Condition="'$(NetCoreBuild)' != 'true' AND !Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\SQLProjectsSystem.targets') AND Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets')"
           Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets" />
 
-  <!-- Use generic SQLProjectsSystem.targets for builds using SSMS/Other IDEs which supports SDK Style Projects. 
+  <!-- Use generic SQLProjectsSystem.targets for builds using SSMS/Other IDEs which supports SDK Style Projects.
   It is impossible for both of these targets file to exist simultaneously on their own. -->
   <Import Condition="'$(NetCoreBuild)' != 'true' AND !Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\ssdtprojectsystem.targets') AND Exists('$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\SQLProjectsSystem.targets')"
           Project="$(MSBuildExtensionsPath)\Sdks\Microsoft.SqlProject.Sdk\SQLProjectsSystem.targets" />
@@ -141,7 +149,7 @@
   <PropertyGroup>
     <SqlBuildDependsOn>$(SqlBuildDependsOn);_GenerateSqlBuildDependencyCache</SqlBuildDependsOn>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <!-- Capture SDK version in telemetry -->
     <DacFxTelemetryItems Update="$(MSBuildProjectFullPath)">
@@ -265,6 +273,6 @@
   <!-- Default properties to be evaluated last -->
   <PropertyGroup>
     <EnableDefaultSqlItems Condition=" '$(EnableDefaultSqlItems)' == '' ">true</EnableDefaultSqlItems>
-    <DefaultSqlItemExcludes>$(DefaultSqlItemExcludes);$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**</DefaultSqlItemExcludes> 
+    <DefaultSqlItemExcludes>$(DefaultSqlItemExcludes);$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**</DefaultSqlItemExcludes>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.Build.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/BuildTests.cs
@@ -345,6 +345,131 @@ namespace Microsoft.Build.Sql.Tests
         }
 
         [Test]
+        [Description("Verifies that default TargetFramework is netstandard2.1 when no TargetFramework is specified.")]
+        public void VerifyDefaultTargetFrameworkIsNetStandard21()
+        {
+            // Add a target to print the resolved TargetFramework property
+            ProjectUtils.AddTarget(GetProjectFilePath(), "PrintTargetFrameworkInfo", target =>
+            {
+                target.AfterTargets = "Build";
+                var messageTask = target.AddTask("Message");
+                messageTask.SetParameter("Text", "ResolvedTargetFramework=$(TargetFramework)");
+                messageTask.SetParameter("Importance", "high");
+            });
+
+            // Build without explicitly setting TargetFramework - should use default netstandard2.1
+            int exitCode = this.RunDotnetCommandOnProject("build", out string stdOutput, out string stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Verify default TargetFramework is netstandard2.1
+            StringAssert.Contains("ResolvedTargetFramework=netstandard2.1", stdOutput,
+                "Default TargetFramework should be netstandard2.1 when not explicitly set.");
+        }
+
+        [Test]
+        [Description("Verifies that TargetFrameworkVersion and TargetFrameworkMoniker are correctly derived when TargetFramework is overridden to net472.")]
+        public void VerifyTargetFrameworkVersionCorrectWhenOverriddenToNet472()
+        {
+            // Override TargetFramework to net472
+            ProjectUtils.AddProperties(this.GetProjectFilePath(), new Dictionary<string, string>()
+            {
+                { "TargetFramework", "net472" }
+            });
+
+            // Add a target to print the resolved TF/TFV/TFM properties
+            ProjectUtils.AddTarget(GetProjectFilePath(), "PrintTargetFrameworkInfo", target =>
+            {
+                target.AfterTargets = "Build";
+                var messageTask = target.AddTask("Message");
+                messageTask.SetParameter("Text", "ResolvedTF=$(TargetFramework)|ResolvedTFV=$(TargetFrameworkVersion)|ResolvedTFM=$(TargetFrameworkMoniker)");
+                messageTask.SetParameter("Importance", "high");
+            });
+
+            int exitCode = this.RunDotnetCommandOnProject("build", out string stdOutput, out string stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Verify TFV and TFM are correctly derived for net472 (not stale netstandard2.1 values)
+            StringAssert.Contains("ResolvedTF=net472", stdOutput,
+                "TargetFramework should be net472.");
+            StringAssert.Contains("ResolvedTFV=v4.7.2", stdOutput,
+                "TargetFrameworkVersion should be v4.7.2, not the stale v2.1 from Sdk.props default.");
+            StringAssert.Contains("ResolvedTFM=.NETFramework,Version=v4.7.2", stdOutput,
+                "TargetFrameworkMoniker should be .NETFramework,Version=v4.7.2, not the stale .NETStandard value.");
+        }
+
+        [Test]
+        [Description("Verifies that TargetFrameworkVersion and TargetFrameworkMoniker match when TargetFramework stays at the default netstandard2.1.")]
+        public void VerifyTargetFrameworkVersionCorrectWithDefaultNetStandard21()
+        {
+            // Add a target to print the resolved TF/TFV/TFM properties (no explicit TargetFramework set)
+            ProjectUtils.AddTarget(GetProjectFilePath(), "PrintTargetFrameworkInfo", target =>
+            {
+                target.AfterTargets = "Build";
+                var messageTask = target.AddTask("Message");
+                messageTask.SetParameter("Text", "ResolvedTF=$(TargetFramework)|ResolvedTFV=$(TargetFrameworkVersion)|ResolvedTFM=$(TargetFrameworkMoniker)");
+                messageTask.SetParameter("Importance", "high");
+            });
+
+            int exitCode = this.RunDotnetCommandOnProject("build", out string stdOutput, out string stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Verify TFV and TFM are consistent with netstandard2.1
+            StringAssert.Contains("ResolvedTF=netstandard2.1", stdOutput,
+                "TargetFramework should be netstandard2.1.");
+            StringAssert.Contains("ResolvedTFV=v2.1", stdOutput,
+                "TargetFrameworkVersion should be v2.1 for netstandard2.1.");
+            StringAssert.Contains("ResolvedTFM=.NETStandard,Version=v2.1", stdOutput,
+                "TargetFrameworkMoniker should be .NETStandard,Version=v2.1.");
+        }
+
+        [Test]
+        [Description("Verifies that TargetFrameworkVersion is correctly derived when TargetFramework is overridden to net8.0.")]
+        public void VerifyTargetFrameworkVersionCorrectWhenOverriddenToNet80()
+        {
+            // Override TargetFramework to net8.0
+            ProjectUtils.AddProperties(this.GetProjectFilePath(), new Dictionary<string, string>()
+            {
+                { "TargetFramework", "net8.0" }
+            });
+
+            // Add a target to print the resolved TF/TFV/TFM properties
+            ProjectUtils.AddTarget(GetProjectFilePath(), "PrintTargetFrameworkInfo", target =>
+            {
+                target.AfterTargets = "Build";
+                var messageTask = target.AddTask("Message");
+                messageTask.SetParameter("Text", "ResolvedTF=$(TargetFramework)|ResolvedTFV=$(TargetFrameworkVersion)|ResolvedTFM=$(TargetFrameworkMoniker)");
+                messageTask.SetParameter("Importance", "high");
+            });
+
+            int exitCode = this.RunDotnetCommandOnProject("build", out string stdOutput, out string stdError);
+
+            // Verify success
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            // Verify TFV and TFM are correctly derived for net8.0 (not stale netstandard2.1 values)
+            StringAssert.Contains("ResolvedTF=net8.0", stdOutput,
+                "TargetFramework should be net8.0.");
+            StringAssert.Contains("ResolvedTFV=v8.0", stdOutput,
+                "TargetFrameworkVersion should be v8.0, not the stale v2.1 from Sdk.props default.");
+            StringAssert.Contains("ResolvedTFM=.NETCoreApp,Version=v8.0", stdOutput,
+                "TargetFrameworkMoniker should be .NETCoreApp,Version=v8.0, not the stale .NETStandard value.");
+        }
+
+        [Test]
         // https://github.com/microsoft/DacFx/issues/117
         public void VerifyBuildWithReleaseConfiguration()
         {


### PR DESCRIPTION
…NetCoreBuild projects

# Description

Updates the default TargetFramework in Sdk.props from net472 / .NETFramework to netstandard2.1 / .NETStandard for projects where NetCoreBuild is false (Visual Studio / non-CLI builds). This makes netstandard2.1 the baseline, while still allowing users to opt into net472 for SQLCLR assembly scenarios.

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
