### PR TITLE
Ship Microsoft.ApplicationInsights.dll with Microsoft.Build.Sql SDK

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Microsoft.SqlServer.Types" Version="170.1000.7" />
     <PackageVersion Include="NuGet.Versioning" Version="6.13.2" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="System.IO.Packaging" Version="8.0.1" />
 
     <!-- Test -->

--- a/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
+++ b/src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj
@@ -43,6 +43,7 @@
     <PackageReference Include="NuGet.Versioning" GeneratePathProperty="true" />
     <PackageReference Include="System.ComponentModel.Composition" GeneratePathProperty="true" />
     <PackageReference Include="System.IO.Packaging" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.ApplicationInsights" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Target Name="CopyNetCoreBinaries"
@@ -59,6 +60,7 @@
       <PackageFilesNetCore Include="$(PkgMicrosoft_SqlServer_Types)\lib\netstandard2.0\Microsoft.SqlServer.Types.dll" />
       <PackageFilesNetCore Include="$(PkgSystem_ComponentModel_Composition)\lib\net8.0\System.ComponentModel.Composition.dll" />
       <PackageFilesNetCore Include="$(PkgSystem_IO_Packaging)\lib\net8.0\System.IO.Packaging.dll" />
+      <PackageFilesNetCore Include="$(PkgMicrosoft_ApplicationInsights)\lib\netstandard2.0\Microsoft.ApplicationInsights.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(PackageFilesNetCore)" DestinationFolder="$(SdkBinariesPath)\%(PackageFilesNetCore.RecursiveDir)" />
   </Target>
@@ -77,6 +79,7 @@
       <PackageFilesNetFramework Include="$(PkgMicrosoft_SqlServer_Types)\lib\net472\Microsoft.SqlServer.Types.dll" />
       <PackageFilesNetFramework Include="$(PkgNuGet_Versioning)\lib\net472\NuGet.Versioning.dll" />
       <PackageFilesNetFramework Include="$(PkgSystem_IO_Packaging)\lib\net462\System.IO.Packaging.dll" />
+      <PackageFilesNetFramework Include="$(PkgMicrosoft_ApplicationInsights)\lib\net46\Microsoft.ApplicationInsights.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(PackageFilesNetFramework)" DestinationFolder="$(SdkBinariesPath)\%(PackageFilesNetFramework.RecursiveDir)" />
   </Target>


### PR DESCRIPTION
# Description

Adds `Microsoft.ApplicationInsights` (2.23.0) as a runtime asset that is staged into the `Microsoft.Build.Sql` SDK NuGet package, so the DacFx tasks loaded by consumers can resolve `Microsoft.ApplicationInsights.dll` at build time using MSBuild.

Background

- `src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj` builds an MSBuild SDK and sets `SuppressDependenciesWhenPacking=true`, so transitive NuGet dependencies are not surfaced to the sqlproj that consumes the SDK.
- DacFx assemblies hosted by the SDK reference `Microsoft.ApplicationInsights`. Without explicitly staging the assembly, consumer builds rely on transitive resolution that is not guaranteed in every host.

Changes

- Added central `PackageVersion` for `Microsoft.ApplicationInsights` 2.23.0 in `Directory.Packages.props`.
- Added a `PackageReference` (with `GeneratePathProperty="true"`) in `src/Microsoft.Build.Sql/Microsoft.Build.Sql.csproj`.
- Staged `Microsoft.ApplicationInsights.dll` into both `tools/net8.0/` (from `lib/netstandard2.0`) and `tools/net472/` (from `lib/net46`).

Backward Compatibility

- No public API or SDK contract changes.
- No action required from customers.

# Code Changes

- [x] Unit tests are added, if possible - N/A (no behavior change; existing build/pack/publish/template tests pass on net8.0).
- [x] Existing tests are passing (`dotnet test` on `Microsoft.Build.Sql.Tests` net8.0: 72/72 passed).
- [x] New or updated code follows the guidelines [here](https://github.com/microsoft/DacFx/blob/main/CONTRIBUTING.md).
- [x] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage.
- [x] Use proper logging for MSBuild tasks (no logging surface changes).
