### PR TITLE
DacFx Release 170.5.29-preview and SDK 2.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <!-- Let CI pipelines to set these for testing dependencies -->
-    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">170.4.83</DacFxPackageVersion>
+    <DacFxPackageVersion Condition="'$(DacFxPackageVersion)' == ''">170.5.29-preview</DacFxPackageVersion>
     <ScriptDomPackageVersion Condition="'$(ScriptDomPackageVersion)' == ''">180.18.1</ScriptDomPackageVersion>
     <SqlClientPackageVersion Condition="'$(SqlClientPackageVersion)' == ''">6.1.5</SqlClientPackageVersion>
   </PropertyGroup>

--- a/release-notes/Microsoft.Build.Sql/2.3.0-preview.1.md
+++ b/release-notes/Microsoft.Build.Sql/2.3.0-preview.1.md
@@ -1,0 +1,14 @@
+# Release Notes
+
+## Microsoft.Build.Sql 2.3.0-preview.1 - 2026-06-17
+
+This update brings the below changes over the previous release:
+
+### Added
+* Includes Microsoft.ApplicationInsights.dll with Microsoft.Build.Sql SDK
+
+### Changed
+* Updated DacFx version to 170.5.xx-preview.
+* Change default TargetFramework from net472 to netstandard2.1 for non NetCoreBuild [#791](https://github.com/microsoft/DacFx/pull/791)
+
+

--- a/release-notes/Microsoft.Build.Sql/README.md
+++ b/release-notes/Microsoft.Build.Sql/README.md
@@ -4,6 +4,7 @@ The following Microsoft.Build.Sql and Microsoft.Build.Sql.Templates releases hav
 
 | Release Date | Version | Notes |
 | :-- | :-- | :--: |
+| 2026-06-17 | 2.3.0-preview.1 | [release notes](2.3.0-preview.1.md) |
 | 2026-06-03 | 2.2.0 | [release notes](2.2.0.md) |
 | 2026-05-08 | 2.2.0-preview.3 | [release notes](2.2.0-preview.3.md) |
 | 2026-03-19 | 2.2.0-preview.2 | [release notes](2.2.0-preview.2.md) |

--- a/release-notes/Microsoft.SqlPackage/170.5/170.5.29-preview.md
+++ b/release-notes/Microsoft.SqlPackage/170.5/170.5.29-preview.md
@@ -1,0 +1,13 @@
+# Release Notes
+
+## Microsoft.SqlPackage 170.5.29-preview
+
+This update brings the below changes over the previous release:
+
+### Adds
+
+### Fixed
+* Fixes DacFx generates unecessary "ALTER TRIGGER" when trigger schema is not defined[#761](https://github.com/microsoft/DacFx/issues/761)
+* Fixes sqlpackage build fails when referencing external data (eg openrowset)[#802](https://github.com/microsoft/DacFx/issues/802)
+### Changed
+

--- a/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.29-preview.md
+++ b/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.29-preview.md
@@ -1,0 +1,13 @@
+# Release Notes
+
+## Microsoft.SqlServer.DacFx 170.5.29-preview
+
+This update brings the below changes over the previous release:
+
+### Adds
+
+### Fixed
+* Fixes DacFx generates unecessary "ALTER TRIGGER" when trigger schema is not defined[#761](https://github.com/microsoft/DacFx/issues/761)
+* Fixes sqlpackage build fails when referencing external data (eg openrowset)[#802](https://github.com/microsoft/DacFx/issues/802)
+### Changed
+

--- a/samples/SdkStyleDatabaseProject/sample.sqlproj
+++ b/samples/SdkStyleDatabaseProject/sample.sqlproj
@@ -5,6 +5,7 @@
     <Name>sample</Name>
     <DSP>Microsoft.Data.Tools.Schema.Sql.Sql150DatabaseSchemaProvider</DSP>
     <ModelCollation>1033, CI</ModelCollation>
+    <ProjectGuid>{00000000-0000-0000-0000-000000000000}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
     <PreDeploy Include="Script.PreDeployment1.sql" />

--- a/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
+++ b/test/Microsoft.Build.Sql.Tests/DotnetTestBase.cs
@@ -172,6 +172,10 @@ namespace Microsoft.Build.Sql.Tests
             string executablePath = TestUtils.DotnetPath;
 #endif
 
+            if (!File.Exists(executablePath))
+            {
+                throw new FileNotFoundException("Executable not found: " + executablePath);
+            }
             ProcessStartInfo dotnetStartInfo = new ProcessStartInfo
             {
                 FileName = executablePath,

--- a/test/Microsoft.Build.Sql.Tests/ProjectUtils.cs
+++ b/test/Microsoft.Build.Sql.Tests/ProjectUtils.cs
@@ -18,15 +18,15 @@ namespace Microsoft.Build.Sql.Tests
         {
             using (ProjectCollection projectCollection = GetNewEngine())
             {
-                Project project = new Project(projectFilePath, null, "Current", projectCollection, ProjectLoadSettings.IgnoreMissingImports);
+                ProjectRootElement project = ProjectRootElement.Open(projectFilePath, projectCollection)!;
 
-                ProjectPropertyGroupElement propertyGroup = project.Xml.AddPropertyGroup();
+                ProjectPropertyGroupElement propertyGroup = project.AddPropertyGroup();
                 foreach (KeyValuePair<string, string> property in properties)
                 {
                     propertyGroup.AddProperty(property.Key, property.Value);
                 }
 
-                project.Save(project.FullPath);
+                project.Save(projectFilePath);
                 projectCollection.UnloadAllProjects();
             }
         }
@@ -47,17 +47,17 @@ namespace Microsoft.Build.Sql.Tests
             {
                 using (ProjectCollection projectCollection = GetNewEngine())
                 {
-                    Project project = new Project(projectFilePath, null, "Current", projectCollection, ProjectLoadSettings.IgnoreMissingImports);
+                    ProjectRootElement project = ProjectRootElement.Open(projectFilePath, projectCollection)!;
 
-                    ProjectItemGroupElement itemGroup = project.Xml.AddItemGroup();
+                    ProjectItemGroupElement itemGroup = project.AddItemGroup();
                     foreach (string filePath in filePaths)
                     {
-                        ProjectItemElement item = project.Xml.CreateItemElement(itemName, filePath);
+                        ProjectItemElement item = project.CreateItemElement(itemName, filePath);
                         itemGroup.AppendChild(item);
                         addMetadata?.Invoke(item);
                     }
 
-                    project.Save(project.FullPath);
+                    project.Save(projectFilePath);
                     projectCollection.UnloadAllProjects();
                 }
             }
@@ -78,17 +78,17 @@ namespace Microsoft.Build.Sql.Tests
             {
                 using (ProjectCollection projectCollection = GetNewEngine())
                 {
-                    Project project = new Project(projectFilePath, null, "Current", projectCollection, ProjectLoadSettings.IgnoreMissingImports);
+                    ProjectRootElement project = ProjectRootElement.Open(projectFilePath, projectCollection)!;
 
-                    ProjectItemGroupElement itemGroup = project.Xml.AddItemGroup();
+                    ProjectItemGroupElement itemGroup = project.AddItemGroup();
                     foreach (string filePath in filePaths)
                     {
-                        var removeItem = project.Xml.CreateItemElement(itemName);
+                        var removeItem = project.CreateItemElement(itemName);
                         removeItem.Remove = filePath;
                         itemGroup.AppendChild(removeItem);
                     }
 
-                    project.Save(project.FullPath);
+                    project.Save(projectFilePath);
                     projectCollection.UnloadAllProjects();
                 }
             }
@@ -98,12 +98,12 @@ namespace Microsoft.Build.Sql.Tests
         {
             using (ProjectCollection projectCollection = GetNewEngine())
             {
-                Project project = new Project(projectFilePath, null, "Current", projectCollection, ProjectLoadSettings.IgnoreMissingImports);
+                ProjectRootElement project = ProjectRootElement.Open(projectFilePath, projectCollection)!;
 
-                ProjectTargetElement target = project.Xml.AddTarget(targetName);
+                ProjectTargetElement target = project.AddTarget(targetName);
                 targetAction(target);
 
-                project.Save(project.FullPath);
+                project.Save(projectFilePath);
                 projectCollection.UnloadAllProjects();
             }
         }

--- a/test/Microsoft.Build.Sql.Tests/TestUtils.cs
+++ b/test/Microsoft.Build.Sql.Tests/TestUtils.cs
@@ -74,8 +74,8 @@ namespace Microsoft.Build.Sql.Tests
                     return msbuildPath;
                 }
 
-                // Fallback to default MSBuild path for Visual Studio 2022
-                return @"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe";
+                // Fallback to default MSBuild path for Visual Studio 2026
+                return @"C:\Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin\MSBuild.exe";
             }
         }
 


### PR DESCRIPTION
# Description

Release notes for DacFx Release 170.5.29-preview and SDK 2.3. Updating Dacfx to 170.5.29-preview in the SDK

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
