### PR TITLE
DacFx Release 170.5.38

### DIFF
--- a/release-notes/Microsoft.SqlPackage/170.5/170.5.38-preview.md
+++ b/release-notes/Microsoft.SqlPackage/170.5/170.5.38-preview.md
@@ -1,0 +1,17 @@
+# Release Notes
+
+## Microsoft.SqlServer.DacFx 170.5.38-preview
+
+This update brings the below changes over the previous release:
+
+### Adds
+* Adds `SkipExistingModelValidation` to `TSqlObjectOptions` so model add, update, and delete operations can proceed when the model already has errors, supporting live IntelliSense model updates in SQL projects
+
+### Fixed
+* Fixes `DoNotDropExtendedProperties=True` not being honored due to conflicting deployment options [#139](https://github.com/microsoft/DacFx/issues/139)
+* Fixes Schema Compare against a Microsoft Fabric Warehouse leaking primary key and other constraints of excluded tables into the generated deployment script
+* Fixes reverse engineering failing with `SQL72018: SqlExternalLanguage could not be imported` on SQL Server 2027 when system-defined external languages are present
+* Fixes Extract to a SQL project emitting per-batch `SET ANSI_NULLS` / `SET QUOTED_IDENTIFIER` options into the generated `.sqlproj`, which broke deployment of objects that require those options on Microsoft Fabric
+
+### Changed
+* Updates Microsoft.SqlServer.TransactSql.ScriptDom to 180.37.3

--- a/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.38-preview.md
+++ b/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.38-preview.md
@@ -1,0 +1,17 @@
+# Release Notes
+
+## Microsoft.SqlServer.DacFx 170.5.38-preview
+
+This update brings the below changes over the previous release:
+
+### Adds
+* Adds `SkipExistingModelValidation` to `TSqlObjectOptions` so model add, update, and delete operations can proceed when the model already has errors, supporting live IntelliSense model updates in SQL projects
+
+### Fixed
+* Fixes `DoNotDropExtendedProperties=True` not being honored due to conflicting deployment options [#139](https://github.com/microsoft/DacFx/issues/139)
+* Fixes Schema Compare against a Microsoft Fabric Warehouse leaking primary key and other constraints of excluded tables into the generated deployment script
+* Fixes reverse engineering failing with `SQL72018: SqlExternalLanguage could not be imported` on SQL Server 2027 when system-defined external languages are present
+* Fixes Extract to a SQL project emitting per-batch `SET ANSI_NULLS` / `SET QUOTED_IDENTIFIER` options into the generated `.sqlproj`, which broke deployment of objects that require those options on Microsoft Fabric
+
+### Changed
+* Updates Microsoft.SqlServer.TransactSql.ScriptDom to 180.37.3


### PR DESCRIPTION
# Description
Release notes for DacFx Release 170.5.38-preview. 

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
