### PR TITLE
Add test for direct .dacpac ArtifactReference (database reference)

### DIFF
--- a/test/Microsoft.Build.Sql.Tests/BuildTests.cs
+++ b/test/Microsoft.Build.Sql.Tests/BuildTests.cs
@@ -535,6 +535,43 @@ namespace Microsoft.Build.Sql.Tests
         }
 
         [Test]
+        [Description("Verifies that a sqlproj referencing a prebuilt .dacpac directly via an ArtifactReference (database reference) builds and resolves the reference. This exercises the ArtifactReference code path (as opposed to ProjectReference or PackageReference) and confirms _RemoveDacpacFromCompileReferences does not strip it from the SQL model. See https://github.com/microsoft/DacFx/issues/785")]
+        public void BuildWithDacpacArtifactReference()
+        {
+            // Build a ReferenceProj to produce a .dacpac that we can reference directly.
+            string tempFolder = TestUtils.CreateTempDirectory();
+            TestUtils.CopyDirectoryRecursive(Path.Combine(this.CommonTestDataDirectory, "ReferenceProj"), tempFolder);
+
+            // The temp folder lives under the repo tree, so copy the isolation files from the test Template
+            // to stop it inheriting the repo's Directory.Build.props (artifacts output layout / central package
+            // management). This keeps the dacpac at the standard bin/Debug path.
+            foreach (string isolationFile in new[] { "Directory.Build.props", "Directory.Build.targets", "Directory.Packages.props" })
+            {
+                File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "Template", isolationFile), Path.Combine(tempFolder, isolationFile), overwrite: true);
+            }
+
+            string referenceProjectPath = Path.Combine(tempFolder, "ReferenceProj.sqlproj");
+            int referenceExitCode = this.RunDotnetCommandOnProject("build", out _, out string referenceStdError, projectPath: referenceProjectPath);
+            Assert.AreEqual(0, referenceExitCode, "Reference project build failed with error " + referenceStdError);
+
+            string dacpacPath = Path.Combine(tempFolder, "bin", "Debug", "ReferenceProj.dacpac");
+            FileAssert.Exists(dacpacPath, "Reference project dacpac was not produced.");
+
+            // Reference the prebuilt dacpac directly as an ArtifactReference and consume it via a synonym + view
+            ProjectUtils.AddItemGroup(this.GetProjectFilePath(), "ArtifactReference", new string[] { dacpacPath }, item =>
+            {
+                item.AddMetadata("DatabaseSqlCmdVariable", "ReferenceDb");
+            });
+
+            int exitCode = this.RunDotnetCommandOnProject("build", out _, out string stdError);
+            Assert.AreEqual(0, exitCode, "Build failed with error " + stdError);
+            Assert.AreEqual(string.Empty, stdError);
+            this.VerifyDacPackage();
+
+            Directory.Delete(tempFolder, true);
+        }
+
+        [Test]
         // https://github.com/microsoft/DacFx/issues/561
         public void FailBuildOnDuplicatedItems()
         {

--- a/test/Microsoft.Build.Sql.Tests/TestData/BuildWithDacpacArtifactReference/Synonym1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/BuildWithDacpacArtifactReference/Synonym1.sql
@@ -1,0 +1,1 @@
+CREATE SYNONYM Synonym1 FOR [$(ReferenceDb)].[dbo].[Table1]

--- a/test/Microsoft.Build.Sql.Tests/TestData/BuildWithDacpacArtifactReference/View1.sql
+++ b/test/Microsoft.Build.Sql.Tests/TestData/BuildWithDacpacArtifactReference/View1.sql
@@ -1,0 +1,2 @@
+CREATE VIEW [dbo].[View1]
+	AS SELECT * FROM Synonym1


### PR DESCRIPTION
# Add test for direct `.dacpac` ArtifactReference (database reference)

**Branch:** `test/785-dacpac-artifact-reference` → base `fix/5270647-sqlclr-build-sql-sdk`
**Related:** #785 (SDK-style SQLCLR / PR #803)

## Summary

Adds a regression test for the one SQL-project reference type that had no dedicated coverage: a **direct `.dacpac` database reference** (an `ArtifactReference`), as opposed to a `ProjectReference` or a `PackageReference`.

This closes the coverage gap raised in review while validating PR #803's `_RemoveDacpacFromCompileReferences` target — which strips `.dacpac` entries out of the Roslyn compile reference set (`@(ReferencePath)`) so `csc` no longer fails with `CS0009` once `CoreCompile` runs for every sqlproj.

## Why this test

A SQL project can reference:

| Reference type | How the dacpac reaches the model | Prior test coverage |
|---|---|---|
| Another project that builds to a dacpac (`ProjectReference`) | `@(_AllSqlReferenceTargetPath)` | ✅ `VerifyBuildWithProjectReference`, `VerifyBuildWithTransitiveProjectReferences`, `BuildWithExternalReference`, `VerifyPublishWithProjectReference` |
| A dacpac directly (`ArtifactReference`) | `@(ArtifactReference)` | ❌ **none** → added here |
| A package ref containing a dacpac (incl. system `master`/`msdb`) | `@(ArtifactReference)` via `ResolveDacpacPackageReferences` | ✅ `PackageReferenceTests`, publish `master.dacpac` |
| A package ref containing a .NET library (analyzers today) | `.dll` in `@(ReferencePath)` (filter only matches `.dacpac`) | ✅ `CodeAnalysisTests` |

The `_RemoveDacpacFromCompileReferences` filter only touches `@(ReferencePath)` / `@(ReferencePathWithRefAssemblies)`. Because a direct `ArtifactReference` never enters `@(ReferencePath)`, it is unaffected — but there was no test to pin that. This adds one.

## What the test does

`BuildTests.BuildWithDacpacArtifactReference`:
1. Builds `ReferenceProj` to a `.dacpac` (isolating the temp build from the repo's `Directory.Build.props` artifacts layout / CPM by copying the test Template's `Directory.*` files, so the dacpac lands at the standard `bin/Debug` path).
2. Adds `<ArtifactReference Include="…/ReferenceProj.dacpac"><DatabaseSqlCmdVariable>ReferenceDb</DatabaseSqlCmdVariable></ArtifactReference>`.
3. Consumes the referenced object through a synonym + view (`Synonym1.sql` on `[$(ReferenceDb)].[dbo].[Table1]`, `View1.sql` on the synonym), so the reference **must resolve** for the build to succeed.
4. Asserts a clean build and a valid dacpac.

## Files

- `test/Microsoft.Build.Sql.Tests/BuildTests.cs` — new `BuildWithDacpacArtifactReference` test.
- `test/Microsoft.Build.Sql.Tests/TestData/BuildWithDacpacArtifactReference/Synonym1.sql`
- `test/Microsoft.Build.Sql.Tests/TestData/BuildWithDacpacArtifactReference/View1.sql`

## Validation

Passes on both build drivers:

| Driver | Result |
|---|---|
| dotnet CLI (net8.0) | ✅ 1/1 |
| Full MSBuild (net472) | ✅ 1/1 |

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
