### PR TITLE
Adding dacfx release notes

### DIFF
--- a/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
+++ b/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
@@ -15,7 +15,6 @@ This update brings the below changes over the previous release:
 * Fixes non-deterministic object ordering when creating and updating a SQL project [#795](https://github.com/microsoft/DacFx/issues/795)
 * Fixes a redundant `ALTER TABLE ... ADD CONSTRAINT` emitted when publishing inline constraints from a project [#792](https://github.com/microsoft/DacFx/issues/792)
 * Fixes an `InvalidCastException` when extracting an object-level permission on a SECURITY POLICY [#800](https://github.com/microsoft/DacFx/issues/800)
-* Fixes DACPAC extract producing `ModelSchemaVersion` "2.4" instead of "2.6" for models without filegroups
 * Fixes a large BACPAC export failing with a "Stream was too long" overflow on `System.IO.Packaging`
 * Fixes a `SQL72008` build error when pre/post-deploy scripts reference `$(DacVersion)` / `$(DacVersion_Previous)`
 * Fixes BACPAC export of Always Encrypted large fixed-length columns
@@ -26,7 +25,6 @@ This update brings the below changes over the previous release:
 * Fixes `sp_addextendedproperty` with `@level1type=N'NULL'` for an extended property on a SECURITY POLICY
 * Fixes Table Designer identity default validation
 * Fixes stale Table Designer cache access token callbacks
-* Fixes the SqlDwUnified (Fabric Warehouse) platform incorrectly mapping to `Sql150`
 * Fixes error message location format to use `(line,col)` instead of `(line,col,line,col)`
 
 ### Changed

--- a/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
+++ b/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
@@ -8,6 +8,7 @@ This update brings the below changes over the previous release:
 
 * Adds editing of VECTOR column dimensions and base type in Table Designer
 * Adds support for VECTOR column dimensions and base types in table-valued parameters and function return types
+* Adds support for `LogDeployment` (T/F) and `EnableFastComparison` (T/F) publish properties, which leverage an automatically managed table `dbo.__DacFxDeploymentHistory` in the target database to track "DacVersions". Fast comparison assumes no drift between last deployment and current state. New SQLCMD variable `DacVersion_Previous` is determined based on the contents of `dbo.__DacFxDeploymentHistory` when `LogDeployment` publish property is set to true.
 
 ### Fixed
 * Fixes generation of an incorrect drop statement for unnamed default constraints [#807](https://github.com/microsoft/DacFx/issues/807)

--- a/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
+++ b/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
@@ -19,7 +19,6 @@ This update brings the below changes over the previous release:
 * Fixes a `SQL72008` build error when pre/post-deploy scripts reference `$(DacVersion)` / `$(DacVersion_Previous)`
 * Fixes BACPAC export of Always Encrypted large fixed-length columns
 * Fixes `VECTOR_SEARCH` table alias and distance column resolution in SQL project build
-* Fixes deployment of Hekaton native triggers to use `us_english` instead of `english`
 * Fixes reverse engineering of external languages failing on SQL Managed Instance due to an `is_system_language` bind failure
 * Fixes Schema Compare emitting redundant child-element scripts for inline-scriptable elements
 * Fixes `sp_addextendedproperty` with `@level1type=N'NULL'` for an extended property on a SECURITY POLICY

--- a/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
+++ b/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Adds
-* Adds pre-plan script support, including a dacpac artifact, public API, and MSBuild `<PrePlan>` plumbing
+
 * Adds editing of VECTOR column dimensions and base type in Table Designer
 * Adds support for VECTOR column dimensions and base types in table-valued parameters and function return types
 

--- a/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
+++ b/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.60-preview.md
@@ -1,0 +1,32 @@
+# Release Notes
+
+## Microsoft.SqlServer.DacFx 170.5.60-preview
+
+This update brings the below changes over the previous release:
+
+### Adds
+* Adds pre-plan script support, including a dacpac artifact, public API, and MSBuild `<PrePlan>` plumbing
+* Adds editing of VECTOR column dimensions and base type in Table Designer
+* Adds support for VECTOR column dimensions and base types in table-valued parameters and function return types
+
+### Fixed
+* Fixes generation of an incorrect drop statement for unnamed default constraints [#807](https://github.com/microsoft/DacFx/issues/807)
+* Fixes non-deterministic object ordering when creating and updating a SQL project [#795](https://github.com/microsoft/DacFx/issues/795)
+* Fixes a redundant `ALTER TABLE ... ADD CONSTRAINT` emitted when publishing inline constraints from a project [#792](https://github.com/microsoft/DacFx/issues/792)
+* Fixes an `InvalidCastException` when extracting an object-level permission on a SECURITY POLICY [#800](https://github.com/microsoft/DacFx/issues/800)
+* Fixes DACPAC extract producing `ModelSchemaVersion` "2.4" instead of "2.6" for models without filegroups
+* Fixes a large BACPAC export failing with a "Stream was too long" overflow on `System.IO.Packaging`
+* Fixes a `SQL72008` build error when pre/post-deploy scripts reference `$(DacVersion)` / `$(DacVersion_Previous)`
+* Fixes BACPAC export of Always Encrypted large fixed-length columns
+* Fixes `VECTOR_SEARCH` table alias and distance column resolution in SQL project build
+* Fixes deployment of Hekaton native triggers to use `us_english` instead of `english`
+* Fixes reverse engineering of external languages failing on SQL Managed Instance due to an `is_system_language` bind failure
+* Fixes Schema Compare emitting redundant child-element scripts for inline-scriptable elements
+* Fixes `sp_addextendedproperty` with `@level1type=N'NULL'` for an extended property on a SECURITY POLICY
+* Fixes Table Designer identity default validation
+* Fixes stale Table Designer cache access token callbacks
+* Fixes the SqlDwUnified (Fabric Warehouse) platform incorrectly mapping to `Sql150`
+* Fixes error message location format to use `(line,col)` instead of `(line,col,line,col)`
+
+### Changed
+* Updates Microsoft.SqlServer.TransactSql.ScriptDom to 180.59.2


### PR DESCRIPTION
# Description

Release notes for 170.5.60-preview 

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
