### PR TITLE
Release notes

### DIFF
--- a/release-notes/Microsoft.SqlPackage/170.5/170.5.80-preview.md
+++ b/release-notes/Microsoft.SqlPackage/170.5/170.5.80-preview.md
@@ -1,0 +1,5 @@
+# Release Notes
+
+## Microsoft.SqlServer.DacFx 170.5.80
+
+See [release notes](../../Microsoft.SqlServer.DacFx/170.5/170.5.80-preview.md).

--- a/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.80-preview.md
+++ b/release-notes/Microsoft.SqlServer.DacFx/170.5/170.5.80-preview.md
@@ -1,0 +1,18 @@
+# Release Notes
+
+## Microsoft.SqlServer.DacFx 170.5.80
+
+This update brings the below changes over the previous release:
+
+### Adds
+* Adds `SqlCmdVariables` and `TargetPlatform` read-only properties to `DacPackage`, so callers can inspect a package's SQLCMD variables and target platform before deployment.
+
+### Fixed
+* Fixes the deployment preview report not showing default constraints being recreated during a table rebuild caused by column reordering, even though the generated deployment script was already correct [microsoft/vscode-mssql#21132](https://github.com/microsoft/vscode-mssql/issues/21132)
+* Fixes a BACPAC import/deployment failure where a stored procedure referencing an external data source via `OPENROWSET(BULK ..., DATA_SOURCE = ...)` could be deployed before the external data source it depends on [#809](https://github.com/microsoft/DacFx/issues/809)
+* Fixes `EnableFastComparison` not skipping an identical redeploy when the dacpac has no `ProjectGuid` (`Guid.Empty`) (https://github.com/microsoft/DacFx/issues/824)
+* Fixes a BACPAC import leaving a large `VARBINARY(MAX)` value empty when its table's only unique key contains a `NULL` column
+* Fixes legacy DACPAC deserialization failing on non-seekable package part streams
+
+### Changed
+* Updates ScriptDom to 180.102.0


### PR DESCRIPTION
# Description

Release notes 170.5.80-preview

# Code Changes

- [ ] [Unit tests](/test/) are added, if possible
- [ ] Existing [tests are passing](https://github.com/microsoft/DacFx/actions/workflows/pr-validation.yml)
- [ ] New or updated code follows the guidelines [here](/CONTRIBUTING.md)
- [ ] Ensure .dacpac from changes to Microsoft.Build.Sql build process MUST be backwards compatible with older versions of SqlPackage
- [ ] Use proper logging for MSBuild tasks
